### PR TITLE
Adjust test to examine error-condition

### DIFF
--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -59,7 +59,7 @@ test_that("simple case works", {
   expect_true(v("{hello: 'world'}"))
 
   v <- json_validator("schema2.json", "ajv")
-  expect_condition(v("{}", error = TRUE), "hello", class = "validation_error")
+  expect_error(v("{}", error = TRUE), "hello", class = "validation_error")
   expect_null(v("{hello: 'world'}", error = TRUE))
 })
 

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -59,7 +59,7 @@ test_that("simple case works", {
   expect_true(v("{hello: 'world'}"))
 
   v <- json_validator("schema2.json", "ajv")
-  expect_error(v("{}", error = TRUE), "hello")
+  expect_condition(v("{}", error = TRUE), "hello", class = "validation_error")
   expect_null(v("{hello: 'world'}", error = TRUE))
 })
 


### PR DESCRIPTION
This is just a small change - not the change to solve the underlying issues (which I am working towards trying to understand).

I came across this warning when running tests:

```
Warning message:
`v("{}", error = TRUE)` generated a condition with class validation_error/error/condition.
It is less fragile to test custom conditions with `class` 
```

FWIW, I am using testthat v2.1.1.

Using the proposed change, testthat runs without a warning.

Also - I am using Roxygen 6.1.1 now, but the branch uses 6.0.1. Shall I amend this PR to update the Roxygen version?

Thanks!
