### PR TITLE
adapt ajv validator to meta-schema version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,6 @@ Suggests:
   knitr,
   rmarkdown,
   testthat
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -4,10 +4,21 @@ global.Ajv = require('ajv');
 global.AjvSchema4 = require('ajv/lib/refs/json-schema-draft-04.json');
 global.AjvSchema6 = require('ajv/lib/refs/json-schema-draft-06.json');
 
-global.AjvGenerator =
-    new Ajv({allErrors: true, schemaId: 'auto', verbose: true});
-global.AjvGenerator.addMetaSchema(AjvSchema4);
-global.AjvGenerator.addMetaSchema(AjvSchema6);
+global.ajv = new Ajv({allErrors: true, verbose: true})
+                   .addMetaSchema(AjvSchema6);
+
+global.ajv_04 = new Ajv({meta: false, schemaId: 'id', allErrors: true, verbose: true})
+                     .addMetaSchema(AjvSchema4)
+                     .removeKeyword('propertyNames')
+                     .removeKeyword('contains')
+                     .removeKeyword('const')
+                     .removeKeyword('if')
+                     .removeKeyword('then')
+                     .removeKeyword('else');
+
+global.get_meta_schema = function(schema) {
+  return schema.$schema;
+};
 
 global.imjv = require('is-my-json-valid');
 
@@ -5270,7 +5281,7 @@ module.exports={
         "$data": {
             "type": "string",
             "anyOf": [
-                { "format": "relative-json-pointer" }, 
+                { "format": "relative-json-pointer" },
                 { "format": "json-pointer" }
             ]
         }

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -75,7 +75,7 @@ test_that("const keyword is supported in draft-06, not draft-04", {
   }"
 
   expect_true(json_validate("{'a': 'foo'}", schema, engine = "ajv"))
-  ## expect_true(json_validate("{'a': 'bar'}", schema, engine = "ajv"))
+  expect_true(json_validate("{'a': 'bar'}", schema, engine = "ajv"))
 
   ## Switch to draft-06
   schema <- gsub("draft-04", "draft-06", schema)
@@ -102,7 +102,7 @@ test_that("if/then/else keywords are supported in draft-07, not draft-04", {
   }"
 
   expect_true(json_validate("{'a': 5, 'b': 5}", schema, engine = "ajv"))
-  ## expect_true(json_validate("{'a': 0, 'b': 5}", schema, engine = "ajv"))
+  expect_true(json_validate("{'a': 0, 'b': 5}", schema, engine = "ajv"))
 
   ## Switch to draft-07
   schema <- gsub("draft-04", "draft-07", schema)


### PR DESCRIPTION
Address #2, to provide ajv-constructor calls according to the meta-schema "draft" version:

- in JS, provide new functions `global.ajv()`, `global.ajv_04()`, and `global.get_meta_schema()`
  - `global.ajv()` used for draft-06, draft-07
  - `global.ajv_04()` used for draft-04, removes keywords
- in R, call JS to determine the meta-schema version, then call the associated JS validator
- update tests (uncomments tests)
- update Roxygen version

All the newly-uncommented tests pass.