### PR TITLE
Subschema valildation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,9 @@
 Package: jsonvalidate
 Title: Validate 'JSON'
-Version: 1.1.0
+Version: 1.2.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com"),
+    person("Alicia", "Schep", role = "ctb"),
     person("Ian", "Lyttle", role = "ctb"),
     person("Kara", "Woo", role = "ctb"),
     person("Mathias", "Buus", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## jsonvalidate 1.?.?
+
+* JSON can be validated against a subschema (#18, #19, @AliciaSchep)
+
 ## jsonvalidate 1.1.0
 
 * Add support for JSON schema draft 06 and 07 using the [`ajv`](https://github.com/epoberezkin/ajv) node library.  This must be used by passing the `engine` argument to `json_validate` and `json_validator` at present (#2, #11, #15, #16, #17, @karawoo & @ijlyttle)

--- a/R/validate.R
+++ b/R/validate.R
@@ -86,15 +86,11 @@ json_validator_ajv <- function(schema, reference) {
     `draft-06` = "ajv",
     `draft-07` = "ajv",
   )
-
-  #call the generator to create the validator
-  # env$ct$eval(
-  #  sprintf("%s = %s.compile(%s)", name, ajv_name, schema)
-  # )
   
   schema_name <- basename(tempfile("schema_"))
   if (is.null(reference)) reference <- schema_name
 
+  #call the generator to create the validator
   env$ct$eval(
     sprintf("%s = %s.addSchema(%s,'%s').getSchema('%s')",
             name, ajv_name, schema, schema_name, reference)

--- a/R/validate.R
+++ b/R/validate.R
@@ -23,7 +23,6 @@
 json_validator <- function(schema, engine = "imjv", reference = NULL) {
   schema <- get_string(schema)
   if (!is.null(reference) && engine != 'ajv') {
-    # Should this instead use ajv and give a warning?
     stop("reference option only permissible with engine 'ajv'")
   }
   switch(engine,
@@ -88,9 +87,11 @@ json_validator_ajv <- function(schema, reference) {
   )
   
   schema_name <- basename(tempfile("schema_"))
-  if (is.null(reference)) reference <- schema_name
+  if (is.null(reference)) {
+    reference <- schema_name
+  }
 
-  #call the generator to create the validator
+  # call the generator to create the validator
   env$ct$eval(
     sprintf("%s = %s.addSchema(%s,'%s').getSchema('%s')",
             name, ajv_name, schema, schema_name, reference)

--- a/R/validate.R
+++ b/R/validate.R
@@ -10,7 +10,14 @@
 ##'   "imjv" (the default; which uses "is-my-json-valid") and "ajv"
 ##'   (Another JSON Schema Validator).  The latter supports more
 ##'   recent json schema features.
-##'
+##'   
+##' @param reference Reference within schema to use for validating against a 
+##'   sub-schema instead of the full schema passed in. For example
+##'   if the schema has a 'definitions' list including a definition for a 
+##'   'Hello' object, one could pass "#/definitions/Hello" and the validator
+##'   would check that the json is a valid "Hello" object. Only available if 
+##'   \code{engine = 'ajv'}.
+##'   
 ##' @export
 ##' @example man-roxygen/example-json_validator.R
 json_validator <- function(schema, engine = "imjv", reference = NULL) {
@@ -151,6 +158,14 @@ json_validator_ajv <- function(schema, reference) {
 ##'   then the function returns \code{NULL} on success (i.e., call
 ##'   only for the side-effect of an error on failure, like
 ##'   \code{stopifnot}).
+##'   
+##' @param reference Reference within schema to use for validating against a 
+##'   sub-schema instead of the full schema passed in. For example
+##'   if the schema has a 'definitions' list including a definition for a 
+##'   'Hello' object, one could pass "#/definitions/Hello" and the validator
+##'   would check that the json is a valid "Hello" object. Only available if 
+##'   \code{engine = 'ajv'}.
+##' 
 ##' @export
 ##' @example man-roxygen/example-json_validate.R
 json_validate <- function(json, schema, verbose = FALSE, greedy = FALSE,

--- a/man/json_validate.Rd
+++ b/man/json_validate.Rd
@@ -5,7 +5,7 @@
 \title{Validate a json file}
 \usage{
 json_validate(json, schema, verbose = FALSE, greedy = FALSE,
-  error = FALSE, engine = "imjv")
+  error = FALSE, engine = "imjv", reference = NULL)
 }
 \arguments{
 \item{json}{Contents of a json object, or a filename containing
@@ -28,6 +28,13 @@ only for the side-effect of an error on failure, like
 "imjv" (the default; which uses "is-my-json-valid") and "ajv"
 (Another JSON Schema Validator).  The latter supports more
 recent json schema features.}
+
+\item{reference}{Reference within schema to use for validating against a 
+sub-schema instead of the full schema passed in. For example
+if the schema has a 'definitions' list including a definition for a 
+'Hello' object, one could pass "#/definitions/Hello" and the validator
+would check that the json is a valid "Hello" object. Only available if 
+\code{engine = 'ajv'}.}
 }
 \description{
 Validate a single json against a schema.  This is a convenience

--- a/man/json_validator.Rd
+++ b/man/json_validator.Rd
@@ -4,7 +4,7 @@
 \alias{json_validator}
 \title{Create a json validator}
 \usage{
-json_validator(schema, engine = "imjv")
+json_validator(schema, engine = "imjv", reference = NULL)
 }
 \arguments{
 \item{schema}{Contents of the json schema, or a filename
@@ -14,6 +14,13 @@ containing a schema.}
 "imjv" (the default; which uses "is-my-json-valid") and "ajv"
 (Another JSON Schema Validator).  The latter supports more
 recent json schema features.}
+
+\item{reference}{Reference within schema to use for validating against a 
+sub-schema instead of the full schema passed in. For example
+if the schema has a 'definitions' list including a definition for a 
+'Hello' object, one could pass "#/definitions/Hello" and the validator
+would check that the json is a valid "Hello" object. Only available if 
+\code{engine = 'ajv'}.}
 }
 \description{
 Create a validator that can validate multiple json files.

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -110,3 +110,40 @@ test_that("if/then/else keywords are supported in draft-07, not draft-04", {
   expect_true(json_validate("{'a': 5, 'b': 5}", schema, engine = "ajv"))
   expect_false(json_validate("{'a': 5, 'c': 5}", schema, engine = "ajv"))
 })
+
+test_that("subschema validation works", {
+ # Add test here...
+  schema <- "{
+    '$schema': 'http://json-schema.org/draft-06/schema#',
+    'definitions':  {
+      'Goodbye': {
+        type: 'object',
+        properties: {'goodbye': {type: 'string'}},
+        'required': ['goodbye']
+      },
+      'Hello': {
+        type: 'object',
+        properties: {'hello': {type: 'string'}},
+        'required': ['hello']
+      },
+      'Conversation': {
+        'anyOf': [
+          {'$ref': '#/definitions/Hello'},
+          {'$ref': '#/definitions/Goodbye'},
+        ]
+      }
+      },
+    '$ref': '#/definitions/Conversation'
+  }"
+  
+  val_goodbye <- json_validator(schema, "ajv", "#/definitions/Goodbye")
+  
+  expect_true(val_goodbye("{'goodbye': 'failure'}"))
+  expect_false(val_goodbye("{'hello': 'failure'}"))
+  
+  val_hello <- json_validator(schema, "ajv", "#/definitions/Hello")
+  
+  expect_false(val_hello("{'goodbye': 'failure'}"))
+  expect_true(val_hello("{'hello': 'failure'}"))
+  
+})


### PR DESCRIPTION
A PR to add support for validating a subschema #18 

Does not yet add a section to vignette -- the vignette does not look like it's been updated yet to account for the 'ajv' option, so I was wondering if it made sense to split up into a vignette for each engine? or whether it might make sense to introduce that as well in these changes? Not sure if 1 comprehensive versus several smaller vignettes is desired approach @richfitz ?  E.g. I could imagine a small vignette 'Engine choice: imjv versus ajv', and another 'validating subschemas' that are specific to those topics. 

