### PR TITLE
i21: Refactor package ahead of future changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ addons:
   apt:
     packages:
       - libv8-dev
+r_packages: covr
+after_success:
+  - Rscript -e 'covr::codecov()'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## jsonvalidate 1.?.?
 
 * JSON can be validated against a subschema (#18, #19, @AliciaSchep)
+* Validation with `error = TRUE` now returns `TRUE` (not `NULL)` on success
 
 ## jsonvalidate 1.1.0
 

--- a/R/read.R
+++ b/R/read.R
@@ -1,5 +1,5 @@
 read_schema <- function(x, v8) {
-  schema <- get_string(x)
+  schema <- get_string(x, "schema")
   meta_schema_version <- read_meta_schema_version(schema, v8)
 
   list(schema = schema, meta_schema_version = meta_schema_version)

--- a/R/read.R
+++ b/R/read.R
@@ -1,8 +1,21 @@
-read_schema <- function(x) {
+read_schema <- function(x, v8) {
   schema <- get_string(x)
-
-  meta_schema <- env$ct$eval(sprintf("get_meta_schema_version(%s)", schema))
-  meta_schema_version <- get_meta_schema_version(meta_schema)
+  meta_schema_version <- read_meta_schema_version(schema, v8)
 
   list(schema = schema, meta_schema_version = meta_schema_version)
+}
+
+
+read_meta_schema_version <- function(schema, v8) {
+  meta_schema <- v8$eval(sprintf("get_meta_schema_version(%s)", schema))
+
+  regex <- "^http://json-schema.org/(draft-\\d{2})/schema#$"
+  version <- gsub(regex, "\\1", meta_schema)
+
+  versions_legal <- c("draft-04", "draft-06", "draft-07")
+  if (!version %in% versions_legal) {
+    return(NULL)
+  }
+
+  version
 }

--- a/R/read.R
+++ b/R/read.R
@@ -1,0 +1,8 @@
+read_schema <- function(x) {
+  schema <- get_string(x)
+
+  meta_schema <- env$ct$eval(sprintf("get_meta_schema_version(%s)", schema))
+  meta_schema_version <- get_meta_schema_version(meta_schema)
+
+  list(schema = schema, meta_schema_version = meta_schema_version)
+}

--- a/R/util.R
+++ b/R/util.R
@@ -1,0 +1,12 @@
+get_string <- function(x) {
+  if (length(x) == 0L) {
+    stop("zero length input")
+  } else if (!is.character(x)) {
+    stop("Expected a character vector")
+  } else if (length(x) > 1L) {
+    x <- paste(x, collapse = "\n")
+  } else if (file.exists(x) && !inherits(x, "AsIs")) {
+    x <- paste(readLines(x), collapse = "\n")
+  }
+  x
+}

--- a/R/util.R
+++ b/R/util.R
@@ -1,13 +1,20 @@
-get_string <- function(x) {
+get_string <- function(x, what = deparse(substitute(x))) {
   if (length(x) == 0L) {
-    stop("zero length input")
-  } else if (!is.character(x)) {
-    stop("Expected a character vector")
+    stop(sprintf("zero length input for %s", what))
+  }
+  if (!is.character(x)) {
+    stop(sprintf("Expected a character vector for %s", what))
+  }
+
+  ## TODO: this will get looked at in the next PR as we need to force
+  ## filenames better; it's not possible with this approach to error
+  ## if a file is missed through a typo.
+  if (length(x) == 1 && file.exists(x)) {
+    x <- paste(readLines(x), collapse = "\n")
   } else if (length(x) > 1L) {
     x <- paste(x, collapse = "\n")
-  } else if (file.exists(x) && !inherits(x, "AsIs")) {
-    x <- paste(readLines(x), collapse = "\n")
   }
+
   x
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -18,3 +18,8 @@ get_string <- function(x) {
 random_id <- function() {
   basename(tempfile(""))
 }
+
+
+`%||%` <- function(a, b) {
+  if (is.null(a)) b else a
+}

--- a/R/util.R
+++ b/R/util.R
@@ -10,3 +10,11 @@ get_string <- function(x) {
   }
   x
 }
+
+
+## An alternative here would be to drag in ids which has a nice
+## random_id function.  This approach here is at least safe to seed
+## setting
+random_id <- function() {
+  basename(tempfile(""))
+}

--- a/R/validate.R
+++ b/R/validate.R
@@ -33,7 +33,7 @@ json_validator <- function(schema, engine = "imjv", reference = NULL) {
 
 
 json_validator_imjv <- function(schema, context) {
-  name <- basename(tempfile("jv_"))
+  name <- random_id()
   env$ct$eval(sprintf("%s = imjv(%s)", name, schema))
   ret <- function(json, verbose = FALSE, greedy = FALSE, error = FALSE) {
     if (error) {
@@ -67,7 +67,7 @@ json_validator_imjv <- function(schema, context) {
 
 
 json_validator_ajv <- function(schema, reference) {
-  name <- basename(tempfile("jv_"))
+  name <- random_id()
 
   ## determine meta-schema version
   meta_schema <- env$ct$eval(sprintf("get_meta_schema(%s)", schema))

--- a/R/validate.R
+++ b/R/validate.R
@@ -21,7 +21,7 @@
 ##' @example man-roxygen/example-json_validator.R
 json_validator <- function(schema, engine = "imjv", reference = NULL) {
   if (!is.null(reference) && engine != 'ajv') {
-    stop("reference option only permissible with engine 'ajv'")
+    stop("subschema validation only supported with engine 'ajv'")
   }
   v8 <- env$ct
   schema <- read_schema(schema, v8)

--- a/R/validate.R
+++ b/R/validate.R
@@ -69,16 +69,16 @@ json_validator_imjv <- function(schema, context) {
 json_validator_ajv <- function(schema, reference) {
   name <- basename(tempfile("jv_"))
 
-  # determine meta-schema version
+  ## determine meta-schema version
   meta_schema <- env$ct$eval(sprintf("get_meta_schema(%s)", schema))
   meta_schema_version <- get_meta_schema_version(meta_schema)
 
-  # if not recognized, use "draft-07"
+  ## if not recognized, use "draft-07"
   if (is.null(meta_schema_version)) {
     meta_schema_version <- "draft-07"
   }
 
-  # determine the name of the generator-function to call
+  ## determine the name of the generator-function to call
   ajv_name <- switch(
     meta_schema_version,
     `draft-04` = "ajv_04",
@@ -91,7 +91,7 @@ json_validator_ajv <- function(schema, reference) {
     reference <- schema_name
   }
 
-  # call the generator to create the validator
+  ## call the generator to create the validator
   env$ct$eval(
     sprintf("%s = %s.addSchema(%s,'%s').getSchema('%s')",
             name, ajv_name, schema, schema_name, reference)
@@ -173,9 +173,8 @@ json_validate <- function(json, schema, verbose = FALSE, greedy = FALSE,
 }
 
 
-# internal function to determine version given a string
+## internal function to determine version given a string
 get_meta_schema_version <- function(x) {
-
   regex <- "^http://json-schema.org/(draft-\\d{2})/schema#$"
   version <- gsub(regex, "\\1", x)
 

--- a/R/validate.R
+++ b/R/validate.R
@@ -32,7 +32,7 @@ json_validator <- function(schema, engine = "imjv", reference = NULL) {
 }
 
 
-json_validator_imjv <- function(schema) {
+json_validator_imjv <- function(schema, context) {
   name <- basename(tempfile("jv_"))
   env$ct$eval(sprintf("%s = imjv(%s)", name, schema))
   ret <- function(json, verbose = FALSE, greedy = FALSE, error = FALSE) {
@@ -173,19 +173,6 @@ json_validate <- function(json, schema, verbose = FALSE, greedy = FALSE,
 }
 
 
-get_string <- function(x) {
-  if (length(x) == 0L) {
-    stop("zero length input")
-  } else if (!is.character(x)) {
-    stop("Expected a character vector")
-  } else if (length(x) > 1L) {
-    x <- paste(x, collapse = "\n")
-  } else if (file.exists(x) && !inherits(x, "AsIs")) {
-    x <- paste(readLines(x), collapse = "\n")
-  }
-  x
-}
-
 # internal function to determine version given a string
 get_meta_schema_version <- function(x) {
 
@@ -198,12 +185,4 @@ get_meta_schema_version <- function(x) {
   }
 
   version
-}
-
-env <- new.env(parent = emptyenv())
-
-
-.onLoad <- function(libname, pkgname) {
-  env$ct <- V8::v8()
-  env$ct$source(system.file("bundle.js", package = "jsonvalidate"))
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,13 @@
+env <- new.env(parent = emptyenv())
+
+
+prepare_js <- function() {
+  ct <- V8::v8()
+  ct$source(system.file("bundle.js", package = "jsonvalidate"))
+  ct
+}
+
+
+.onLoad <- function(libname, pkgname) {
+  env$ct <- prepare_js()
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,6 +8,8 @@ prepare_js <- function() {
 }
 
 
+## This can't be reliably tested - it's called during package startup
+## and outside of covr's measurements.
 .onLoad <- function(libname, pkgname) {
-  env$ct <- prepare_js()
+  env$ct <- prepare_js() # nocov
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # jsonvalidate
 
+<!-- badges: start -->
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Build Status](https://travis-ci.org/ropensci/jsonvalidate.svg?branch=master)](https://travis-ci.org/ropensci/jsonvalidate)
+[![codecov.io](https://codecov.io/github/ropensci/jsonvalidate/coverage.svg?branch=master)](https://codecov.io/github/ropensci/jsonvalidate?branch=master)
+[![](http://www.r-pkg.org/badges/version/jsonvalidate)](https://cran.r-project.org/package=jsonvalidate)
+<!-- badges: end -->
+
 
 Validate JSON against a schema using [`is-my-json-valid`](https://github.com/mafintosh/is-my-json-valid) or [`ajv`](https://github.com/epoberezkin/ajv).  This package is simply a thin wrapper around these node libraries, using the [V8](https://cran.r-project.org/package=V8) package.
 

--- a/README.md
+++ b/README.md
@@ -8,26 +8,38 @@
 <!-- badges: end -->
 
 
-Validate JSON against a schema using [`is-my-json-valid`](https://github.com/mafintosh/is-my-json-valid) or [`ajv`](https://github.com/epoberezkin/ajv).  This package is simply a thin wrapper around these node libraries, using the [V8](https://cran.r-project.org/package=V8) package.
-
-## Installation
-
-```r
-devtools::install_github("ropensci/jsonvalidate")
-```
+Validate JSON against a schema using [`is-my-json-valid`](https://github.com/mafintosh/is-my-json-valid) or [`ajv`](https://github.com/epoberezkin/ajv).  This package is a thin wrapper around these node libraries, using the [V8](https://cran.r-project.org/package=V8) package.
 
 ## Usage
 
+Directly validate `json` against `schema`
+
 ```r
-jsonvalidate::validate_json(json, schema)
+jsonvalidate::json_validate(json, schema)
 ```
 
-or
+or create a validator for multiple uses
 
 ```r
-validate <- jsonvalidate::validate_json(schema)
+validate <- jsonvalidate::json_validator(schema)
 validate(json)
 validate(json2) # etc
+```
+
+See the [package vignette](https://docs.ropensci.org/jsonvalidate/articles/jsonvalidate.html) for complete examples.
+
+## Installation
+
+Install from CRAN with
+
+```r
+install.packages("jsonvalidate")
+```
+
+Alternatively, the current development version can be installed from GitHub with
+
+```r
+devtools::install_github("ropensci/jsonvalidate")
 ```
 
 ## License

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -1,20 +1,20 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 (function (global){
 global.Ajv = require('ajv');
 global.AjvSchema4 = require('ajv/lib/refs/json-schema-draft-04.json');
 global.AjvSchema6 = require('ajv/lib/refs/json-schema-draft-06.json');
 
 global.ajv = new Ajv({allErrors: true, verbose: true})
-                   .addMetaSchema(AjvSchema6);
+    .addMetaSchema(AjvSchema6);
 
 global.ajv_04 = new Ajv({meta: false, schemaId: 'id', allErrors: true, verbose: true})
-                     .addMetaSchema(AjvSchema4)
-                     .removeKeyword('propertyNames')
-                     .removeKeyword('contains')
-                     .removeKeyword('const')
-                     .removeKeyword('if')
-                     .removeKeyword('then')
-                     .removeKeyword('else');
+    .addMetaSchema(AjvSchema4)
+    .removeKeyword('propertyNames')
+    .removeKeyword('contains')
+    .removeKeyword('const')
+    .removeKeyword('if')
+    .removeKeyword('then')
+    .removeKeyword('else');
 
 global.get_meta_schema = function(schema) {
   return schema.$schema;
@@ -5281,7 +5281,7 @@ module.exports={
         "$data": {
             "type": "string",
             "anyOf": [
-                { "format": "relative-json-pointer" },
+                { "format": "relative-json-pointer" }, 
                 { "format": "json-pointer" }
             ]
         }
@@ -8332,14 +8332,103 @@ if (typeof Object.create === 'function') {
 
 },{}],58:[function(require,module,exports){
 // shim for using process in browser
-
 var process = module.exports = {};
+
+// cached from whatever global is present so that test runners that stub it
+// don't break things.  But we need to wrap it in a try catch in case it is
+// wrapped in strict mode code which doesn't define any globals.  It's inside a
+// function because try/catches deoptimize in certain engines.
+
+var cachedSetTimeout;
+var cachedClearTimeout;
+
+function defaultSetTimout() {
+    throw new Error('setTimeout has not been defined');
+}
+function defaultClearTimeout () {
+    throw new Error('clearTimeout has not been defined');
+}
+(function () {
+    try {
+        if (typeof setTimeout === 'function') {
+            cachedSetTimeout = setTimeout;
+        } else {
+            cachedSetTimeout = defaultSetTimout;
+        }
+    } catch (e) {
+        cachedSetTimeout = defaultSetTimout;
+    }
+    try {
+        if (typeof clearTimeout === 'function') {
+            cachedClearTimeout = clearTimeout;
+        } else {
+            cachedClearTimeout = defaultClearTimeout;
+        }
+    } catch (e) {
+        cachedClearTimeout = defaultClearTimeout;
+    }
+} ())
+function runTimeout(fun) {
+    if (cachedSetTimeout === setTimeout) {
+        //normal enviroments in sane situations
+        return setTimeout(fun, 0);
+    }
+    // if setTimeout wasn't available but was latter defined
+    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+        cachedSetTimeout = setTimeout;
+        return setTimeout(fun, 0);
+    }
+    try {
+        // when when somebody has screwed with setTimeout but no I.E. maddness
+        return cachedSetTimeout(fun, 0);
+    } catch(e){
+        try {
+            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+            return cachedSetTimeout.call(null, fun, 0);
+        } catch(e){
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+            return cachedSetTimeout.call(this, fun, 0);
+        }
+    }
+
+
+}
+function runClearTimeout(marker) {
+    if (cachedClearTimeout === clearTimeout) {
+        //normal enviroments in sane situations
+        return clearTimeout(marker);
+    }
+    // if clearTimeout wasn't available but was latter defined
+    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+        cachedClearTimeout = clearTimeout;
+        return clearTimeout(marker);
+    }
+    try {
+        // when when somebody has screwed with setTimeout but no I.E. maddness
+        return cachedClearTimeout(marker);
+    } catch (e){
+        try {
+            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+            return cachedClearTimeout.call(null, marker);
+        } catch (e){
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+            return cachedClearTimeout.call(this, marker);
+        }
+    }
+
+
+
+}
 var queue = [];
 var draining = false;
 var currentQueue;
 var queueIndex = -1;
 
 function cleanUpNextTick() {
+    if (!draining || !currentQueue) {
+        return;
+    }
     draining = false;
     if (currentQueue.length) {
         queue = currentQueue.concat(queue);
@@ -8355,7 +8444,7 @@ function drainQueue() {
     if (draining) {
         return;
     }
-    var timeout = setTimeout(cleanUpNextTick);
+    var timeout = runTimeout(cleanUpNextTick);
     draining = true;
 
     var len = queue.length;
@@ -8372,7 +8461,7 @@ function drainQueue() {
     }
     currentQueue = null;
     draining = false;
-    clearTimeout(timeout);
+    runClearTimeout(timeout);
 }
 
 process.nextTick = function (fun) {
@@ -8384,7 +8473,7 @@ process.nextTick = function (fun) {
     }
     queue.push(new Item(fun, args));
     if (queue.length === 1 && !draining) {
-        setTimeout(drainQueue, 0);
+        runTimeout(drainQueue);
     }
 };
 
@@ -8412,6 +8501,10 @@ process.off = noop;
 process.removeListener = noop;
 process.removeAllListeners = noop;
 process.emit = noop;
+process.prependListener = noop;
+process.prependOnceListener = noop;
+
+process.listeners = function (name) { return [] }
 
 process.binding = function (name) {
     throw new Error('process.binding is not supported');

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -67,7 +67,7 @@ global.imjv_call = function(key, value, errors, greedy) {
     return {"success": success, "errors": errors, "engine": "imjv"};
 }
 
-global.cleanup = function(type, name) {
+global.validator_delete = function(type, name) {
     delete validators[type][name];
 }
 

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -72,8 +72,13 @@ global.validator_delete = function(type, name) {
 }
 
 global.get_meta_schema_version = function(schema) {
-  return schema.$schema;
+    return schema.$schema;
 };
+
+global.validator_stats = function() {
+    return {"imjv": Object.keys(validators["imjv"]).length,
+            "ajv": Object.keys(validators["ajv"]).length};
+}
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"ajv":2,"ajv/lib/refs/json-schema-draft-04.json":42,"ajv/lib/refs/json-schema-draft-06.json":43,"is-my-json-valid":51}],2:[function(require,module,exports){

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -4,23 +4,76 @@ global.Ajv = require('ajv');
 global.AjvSchema4 = require('ajv/lib/refs/json-schema-draft-04.json');
 global.AjvSchema6 = require('ajv/lib/refs/json-schema-draft-06.json');
 
-global.ajv = new Ajv({allErrors: true, verbose: true})
-    .addMetaSchema(AjvSchema6);
+global.imjv = require('is-my-json-valid');
 
-global.ajv_04 = new Ajv({meta: false, schemaId: 'id', allErrors: true, verbose: true})
-    .addMetaSchema(AjvSchema4)
-    .removeKeyword('propertyNames')
-    .removeKeyword('contains')
-    .removeKeyword('const')
-    .removeKeyword('if')
-    .removeKeyword('then')
-    .removeKeyword('else');
+// Storage for validators so we can interact with them from R
+global.validators = {"imjv": {}, "ajv": {}}
 
-global.get_meta_schema = function(schema) {
+global.ajv_create_object = function(meta_schema_version) {
+    if (meta_schema_version === "draft-04") {
+        var opts = {meta: false,
+                    schemaId: 'id',
+                    allErrors: true,
+                    verbose: true};
+        return new Ajv(opts)
+            .addMetaSchema(AjvSchema4)
+            .removeKeyword('propertyNames')
+            .removeKeyword('contains')
+            .removeKeyword('const')
+            .removeKeyword('if')
+            .removeKeyword('then')
+            .removeKeyword('else');
+    } else {
+        var opts = {allErrors: true, verbose: true};
+        var ret = new Ajv({allErrors: true, verbose: true});
+        if (meta_schema_version === "draft-06") {
+            ret.addMetaSchema(AjvSchema6);
+        }
+        return ret;
+    }
+}
+
+// TODO: we can push greedy into here
+global.ajv_create = function(key, meta_schema_version, schema, reference) {
+    var ret = ajv_create_object(meta_schema_version);
+    if (reference === null) {
+        ret = ret.compile(schema);
+    } else {
+        ret = ret.addSchema(schema).getSchema(reference);
+    }
+    validators["ajv"][key] = ret;
+}
+
+global.imjv_create = function(key, meta_schema_version, schema) {
+    // https://github.com/mafintosh/is-my-json-valid/issues/160
+    if (meta_schema_version != "draft-04") {
+        throw new Error("Only draft-04 json schema is supported");
+    }
+    var ret = imjv(schema);
+    validators["imjv"][key] = ret;
+}
+
+global.ajv_call = function(key, value, errors) {
+    var validator = validators["ajv"][key];
+    var success = validator(value);
+    var errors = (!success && errors ? validator.errors : null);
+    return {"success": success, "errors": errors, "engine": "ajv"};
+}
+
+global.imjv_call = function(key, value, errors, greedy) {
+    var validator = validators["imjv"][key];
+    var success = validator(value, {"greedy": greedy}, {"verbose": errors});
+    var errors = (!success && errors ? validator.errors : null);
+    return {"success": success, "errors": errors, "engine": "imjv"};
+}
+
+global.cleanup = function(type, name) {
+    delete validators[type][name];
+}
+
+global.get_meta_schema_version = function(schema) {
   return schema.$schema;
 };
-
-global.imjv = require('is-my-json-valid');
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"ajv":2,"ajv/lib/refs/json-schema-draft-04.json":42,"ajv/lib/refs/json-schema-draft-06.json":43,"is-my-json-valid":51}],2:[function(require,module,exports){

--- a/js/in.js
+++ b/js/in.js
@@ -2,9 +2,20 @@ global.Ajv = require('ajv');
 global.AjvSchema4 = require('ajv/lib/refs/json-schema-draft-04.json');
 global.AjvSchema6 = require('ajv/lib/refs/json-schema-draft-06.json');
 
-global.AjvGenerator =
-    new Ajv({allErrors: true, schemaId: 'auto', verbose: true});
-global.AjvGenerator.addMetaSchema(AjvSchema4);
-global.AjvGenerator.addMetaSchema(AjvSchema6);
+global.ajv = new Ajv({allErrors: true, verbose: true})
+    .addMetaSchema(AjvSchema6);
+
+global.ajv_04 = new Ajv({meta: false, schemaId: 'id', allErrors: true, verbose: true})
+    .addMetaSchema(AjvSchema4)
+    .removeKeyword('propertyNames')
+    .removeKeyword('contains')
+    .removeKeyword('const')
+    .removeKeyword('if')
+    .removeKeyword('then')
+    .removeKeyword('else');
+
+global.get_meta_schema = function(schema) {
+  return schema.$schema;
+};
 
 global.imjv = require('is-my-json-valid');

--- a/js/in.js
+++ b/js/in.js
@@ -65,7 +65,7 @@ global.imjv_call = function(key, value, errors, greedy) {
     return {"success": success, "errors": errors, "engine": "imjv"};
 }
 
-global.cleanup = function(type, name) {
+global.validator_delete = function(type, name) {
     delete validators[type][name];
 }
 

--- a/js/in.js
+++ b/js/in.js
@@ -2,20 +2,73 @@ global.Ajv = require('ajv');
 global.AjvSchema4 = require('ajv/lib/refs/json-schema-draft-04.json');
 global.AjvSchema6 = require('ajv/lib/refs/json-schema-draft-06.json');
 
-global.ajv = new Ajv({allErrors: true, verbose: true})
-    .addMetaSchema(AjvSchema6);
+global.imjv = require('is-my-json-valid');
 
-global.ajv_04 = new Ajv({meta: false, schemaId: 'id', allErrors: true, verbose: true})
-    .addMetaSchema(AjvSchema4)
-    .removeKeyword('propertyNames')
-    .removeKeyword('contains')
-    .removeKeyword('const')
-    .removeKeyword('if')
-    .removeKeyword('then')
-    .removeKeyword('else');
+// Storage for validators so we can interact with them from R
+global.validators = {"imjv": {}, "ajv": {}}
 
-global.get_meta_schema = function(schema) {
+global.ajv_create_object = function(meta_schema_version) {
+    if (meta_schema_version === "draft-04") {
+        var opts = {meta: false,
+                    schemaId: 'id',
+                    allErrors: true,
+                    verbose: true};
+        return new Ajv(opts)
+            .addMetaSchema(AjvSchema4)
+            .removeKeyword('propertyNames')
+            .removeKeyword('contains')
+            .removeKeyword('const')
+            .removeKeyword('if')
+            .removeKeyword('then')
+            .removeKeyword('else');
+    } else {
+        var opts = {allErrors: true, verbose: true};
+        var ret = new Ajv({allErrors: true, verbose: true});
+        if (meta_schema_version === "draft-06") {
+            ret.addMetaSchema(AjvSchema6);
+        }
+        return ret;
+    }
+}
+
+// TODO: we can push greedy into here
+global.ajv_create = function(key, meta_schema_version, schema, reference) {
+    var ret = ajv_create_object(meta_schema_version);
+    if (reference === null) {
+        ret = ret.compile(schema);
+    } else {
+        ret = ret.addSchema(schema).getSchema(reference);
+    }
+    validators["ajv"][key] = ret;
+}
+
+global.imjv_create = function(key, meta_schema_version, schema) {
+    // https://github.com/mafintosh/is-my-json-valid/issues/160
+    if (meta_schema_version != "draft-04") {
+        throw new Error("Only draft-04 json schema is supported");
+    }
+    var ret = imjv(schema);
+    validators["imjv"][key] = ret;
+}
+
+global.ajv_call = function(key, value, errors) {
+    var validator = validators["ajv"][key];
+    var success = validator(value);
+    var errors = (!success && errors ? validator.errors : null);
+    return {"success": success, "errors": errors, "engine": "ajv"};
+}
+
+global.imjv_call = function(key, value, errors, greedy) {
+    var validator = validators["imjv"][key];
+    var success = validator(value, {"greedy": greedy}, {"verbose": errors});
+    var errors = (!success && errors ? validator.errors : null);
+    return {"success": success, "errors": errors, "engine": "imjv"};
+}
+
+global.cleanup = function(type, name) {
+    delete validators[type][name];
+}
+
+global.get_meta_schema_version = function(schema) {
   return schema.$schema;
 };
-
-global.imjv = require('is-my-json-valid');

--- a/js/in.js
+++ b/js/in.js
@@ -70,5 +70,10 @@ global.validator_delete = function(type, name) {
 }
 
 global.get_meta_schema_version = function(schema) {
-  return schema.$schema;
+    return schema.$schema;
 };
+
+global.validator_stats = function() {
+    return {"imjv": Object.keys(validators["imjv"]).length,
+            "ajv": Object.keys(validators["ajv"]).length};
+}

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -1,0 +1,30 @@
+context("util")
+
+test_that("get_string error cases", {
+  expect_error(get_string(character(0), "thing"),
+               "zero length input for thing")
+  expect_error(get_string(1, "thing"),
+               "Expected a character vector for thing")
+})
+
+
+test_that("get_string reads files as a string", {
+  path <- tempfile()
+  writeLines(c("some", "test"), path)
+  expect_equal(get_string(path), "some\ntest")
+})
+
+
+test_that("get_string concatenates character vectors", {
+  expect_equal(get_string(c("some", "text")),
+               "some\ntext")
+})
+
+
+test_that("get_string passes along strings", {
+  expect_equal(get_string("some\ntext"),
+               "some\ntext")
+  ## Probably not ideal:
+  expect_equal(get_string("file_that_does_not_exist.json"),
+               "file_that_does_not_exist.json")
+})

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -64,6 +64,24 @@ test_that("simple case works", {
   expect_true(v("{hello: 'world'}", error = TRUE))
 })
 
+
+test_that("verbose output", {
+  schema <- str <- '{
+  "type": "object",
+  required: ["hello"],
+  "properties": {
+    "hello": {
+      "type": "string"
+    }
+  }
+}'
+  v <- json_validator(str, "ajv")
+  res <- v("{}", verbose = TRUE)
+  expect_false(res)
+  expect_is(attr(res, "errors"), "data.frame")
+})
+
+
 test_that("const keyword is supported in draft-06, not draft-04", {
   schema <- "{
     '$schema': 'http://json-schema.org/draft-04/schema#',
@@ -146,4 +164,17 @@ test_that("subschema validation works", {
   
   expect_false(val_hello("{'goodbye': 'failure'}"))
   expect_true(val_hello("{'hello': 'failure'}"))
+})
+
+
+test_that("can't use subschema reference with imjv", {
+  expect_error(json_validator("{}", engine = "imjv",
+                              reference = "definitions/sub"),
+               "subschema validation only supported with engine 'ajv'")
+})
+
+
+test_that("can't use invalid engines", {
+  expect_error(json_validator("{}", engine = "magic"),
+               "Unknown engine 'magic'")
 })

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -30,8 +30,9 @@ test_that("is-my-json-valid", {
 
   v <- json_validator("schema.json")
   expect_error(v("{}", error = TRUE),
-               "data.hello: is required")
-  expect_null(v("{hello: 'world'}", error = TRUE))
+               "data.hello: is required",
+               class = "validation_error")
+  expect_true(v("{hello: 'world'}", error = TRUE))
 })
 
 
@@ -60,7 +61,7 @@ test_that("simple case works", {
 
   v <- json_validator("schema2.json", "ajv")
   expect_error(v("{}", error = TRUE), "hello", class = "validation_error")
-  expect_null(v("{hello: 'world'}", error = TRUE))
+  expect_true(v("{hello: 'world'}", error = TRUE))
 })
 
 test_that("const keyword is supported in draft-06, not draft-04", {
@@ -111,30 +112,30 @@ test_that("if/then/else keywords are supported in draft-07, not draft-04", {
   expect_false(json_validate("{'a': 5, 'c': 5}", schema, engine = "ajv"))
 })
 
+
 test_that("subschema validation works", {
- # Add test here...
-  schema <- "{
-    '$schema': 'http://json-schema.org/draft-06/schema#',
-    'definitions':  {
-      'Goodbye': {
-        type: 'object',
-        properties: {'goodbye': {type: 'string'}},
-        'required': ['goodbye']
+  schema <- '{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions":  {
+      "Goodbye": {
+        type: "object",
+        properties: {"goodbye": {type: "string"}},
+        "required": ["goodbye"]
       },
-      'Hello': {
-        type: 'object',
-        properties: {'hello': {type: 'string'}},
-        'required': ['hello']
+      "Hello": {
+        type: "object",
+        properties: {"hello": {type: "string"}},
+        "required": ["hello"]
       },
-      'Conversation': {
-        'anyOf': [
-          {'$ref': '#/definitions/Hello'},
-          {'$ref': '#/definitions/Goodbye'},
+      "Conversation": {
+        "anyOf": [
+          {"$ref": "#/definitions/Hello"},
+          {"$ref": "#/definitions/Goodbye"},
         ]
       }
       },
-    '$ref': '#/definitions/Conversation'
-  }"
+    "$ref": "#/definitions/Conversation"
+  }'
   
   val_goodbye <- json_validator(schema, "ajv", "#/definitions/Goodbye")
   
@@ -145,5 +146,4 @@ test_that("subschema validation works", {
   
   expect_false(val_hello("{'goodbye': 'failure'}"))
   expect_true(val_hello("{'hello': 'failure'}"))
-  
 })

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -178,3 +178,14 @@ test_that("can't use invalid engines", {
   expect_error(json_validator("{}", engine = "magic"),
                "Unknown engine 'magic'")
 })
+
+
+test_that("package support", {
+  res <- prepare_js()
+  expect_is(res, "V8")
+  expect_setequal(names(res$get("validators")),
+                  c("imjv", "ajv"))
+  s <- res$call("validator_stats")
+  expect_equal(s$imjv, 0)
+  expect_equal(s$ajv, 0)
+})

--- a/vignettes/jsonvalidate.Rmd
+++ b/vignettes/jsonvalidate.Rmd
@@ -9,8 +9,8 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-``` {r echo=FALSE, results="hide"}
-knitr::opts_chunk$set(error=FALSE)
+``` {r echo = FALSE, results = "hide"}
+knitr::opts_chunk$set(error = FALSE)
 ```
 
 This package wraps
@@ -121,10 +121,15 @@ Create a validator:
 v <- jsonvalidate::json_validator(schema)
 ```
 
-If we'd saved the json to a file called `schema.json`, this would work too:
+If we'd saved the json to a file, this would work too:
 ``` {r }
-writeLines(schema, "schema.json")
-v <- jsonvalidate::json_validator("schema.json")
+path <- tempfile()
+writeLines(schema, path)
+v <- jsonvalidate::json_validator(path)
+```
+
+``` {r include = FALSE}
+file.remove(path)
 ```
 
 The returned object is a function that takes as its first argument
@@ -134,9 +139,9 @@ fail validation because it does not contain any of the required fields:
 v("{}")
 ```
 
-To get more information on why the validation fails, add `verbose=TRUE`:
+To get more information on why the validation fails, add `verbose = TRUE`:
 ``` {r }
-v("{}", verbose=TRUE)
+v("{}", verbose = TRUE)
 ```
 
 The attribute "errors" is a data.frame and is present only when the
@@ -144,14 +149,14 @@ json fails validation.  The error messages come straight from
 `is-my-json-valid` and they may not always be that informative.
 
 Alternatively, to throw an error if the json does not validate, add
-`error=TRUE` to the call:
-``` {r error=TRUE}
-v("{}", error=TRUE)
+`error = TRUE` to the call:
+``` {r error = TRUE}
+v("{}", error = TRUE)
 ```
 
-And to continue validating after the first error, pass `greedy=TRUE`:
+And to continue validating after the first error, pass `greedy = TRUE`:
 ``` {r }
-v("{}", verbose=TRUE, greedy=TRUE)
+v("{}", verbose = TRUE, greedy = TRUE)
 ```
 
 which will sometimes show more errors.
@@ -173,7 +178,7 @@ v('{
     "name": "A green door",
     "price": -1,
     "tags": ["home", "green"]
-}', verbose=TRUE)
+}', verbose = TRUE)
 ```
 
 ...or duplicate tags:
@@ -183,7 +188,7 @@ v('{
     "name": "A green door",
     "price": 12.50,
     "tags": ["home", "home"]
-}', verbose=TRUE)
+}', verbose = TRUE)
 ```
 
 or just basically everything wrong:
@@ -193,7 +198,7 @@ v('{
     "name": 1,
     "price": -1,
     "tags": ["home", "home", 1]
-}', verbose=TRUE)
+}', verbose = TRUE)
 ```
 
 The `data.tags.2` name comes from within the `is-my-json-valid`
@@ -209,8 +214,4 @@ json <- '{
     "tags": ["home", "green"]
 }'
 jsonvalidate::json_validate(json, schema)
-```
-
-``` {r echo=FALSE, results="hide"}
-file.remove("schema.json")
 ```


### PR DESCRIPTION
This package came out of the ropensci unconf and was thrown together a bit hastily.  I'd like to make some larger changes shortly but it lacks some support that would make this easier (#21).  This PR will refactor the package to:

* Add code coverage measurement and deal with coverage holes
* Implement garbage collection for the validators (#14)
* Backport changes in 760d970 / #16 into the in.js file 
* Restructure code to make future changes easier
* Classed errors for imjv
