### PR TITLE
i20: Add support for nested schemas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: r
 sudo: false
-dist: trusty
+dist: xenial
 addons:
   apt:
     packages:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jsonvalidate
 Title: Validate 'JSON'
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com"),
     person("Alicia", "Schep", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     V8
 Suggests:
     knitr,
+    jsonlite,
     rmarkdown,
     testthat
 RoxygenNote: 6.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * JSON can be validated against a subschema (#18, #19, @AliciaSchep)
 * Validation with `error = TRUE` now returns `TRUE` (not `NULL)` on success
+* Schemas can span multiple files, being included via `"$ref": "filename.json"` - supported with the ajv engine only (#20, #21, @r-ash).
 
 ## jsonvalidate 1.1.0
 

--- a/R/read.R
+++ b/R/read.R
@@ -85,9 +85,8 @@ read_schema_dependencies <- function(schema, children, parent, v8) {
       read_schema_filename(p, children, parent, v8),
       error = function(e) {
         if (!inherits(e, "jsonvalidate_read_error")) {
-          e$message <- sprintf("While reading %s\n%s",
-                               paste(squote(rev(parent)), collapse = " > "),
-                               e$message)
+          chain <- paste(squote(c(rev(parent), p)), collapse = " > ")
+          e$message <- sprintf("While reading %s\n%s", chain, e$message)
           class(e) <- c("jsonvalidate_read_error", class(e))
           e$call <- NULL
         }

--- a/R/read.R
+++ b/R/read.R
@@ -9,7 +9,10 @@ read_schema <- function(x, v8) {
   children <- new.env(parent = emptyenv())
   parent <- NULL
 
-  if (length(x) == 1 && !inherits(x, "AsIs") && file.exists(x)) {
+  if (read_schema_is_filename(x)) {
+    if (!file.exists(x)) {
+      stop(sprintf("Schema '%s' looks like a filename but does not exist", x))
+    }
     workdir <- dirname(x)
     filename <- basename(x)
     ret <- with_dir(workdir,
@@ -145,4 +148,10 @@ check_schema_versions <- function(schema, dependencies) {
   stop(paste0("Conflicting subschema versions used:\n",
               paste(err, collapse = "\n")),
        call. = FALSE)
+}
+
+
+read_schema_is_filename <- function(x) {
+  RE_JSON <- "[{['\"]"
+  !(length(x) != 1 || inherits(x, "AsIs") || grepl(RE_JSON, x))
 }

--- a/R/read.R
+++ b/R/read.R
@@ -132,7 +132,7 @@ check_schema_versions <- function(schema, dependencies) {
     return(version)
   }
 
-  versions_used <- c(setNames(version, schema$filename %||% "(input string)"),
+  versions_used <- c(set_names(version, schema$filename %||% "(input string)"),
                      versions)
   versions_used_unique <- unique(versions_used)
   if (length(versions_used_unique) == 1L) {

--- a/R/read.R
+++ b/R/read.R
@@ -90,13 +90,18 @@ read_schema_dependencies <- function(schema, children, parent, v8) {
 
 
 read_meta_schema_version <- function(schema, v8) {
-  meta_schema <- v8$eval(sprintf("get_meta_schema_version(%s)", schema))
+  meta_schema <- v8$call("get_meta_schema_version", V8::JS(schema))
+  if (is.null(meta_schema)) {
+    return(NULL)
+  }
 
   regex <- "^http://json-schema.org/(draft-\\d{2})/schema#$"
   version <- gsub(regex, "\\1", meta_schema)
 
+  ## TODO: this is unclear - I think we might be better off erroring
+  ## instead
   versions_legal <- c("draft-04", "draft-06", "draft-07")
-  if (!version %in% versions_legal) {
+  if (!(version %in% versions_legal)) {
     return(NULL)
   }
 

--- a/R/read.R
+++ b/R/read.R
@@ -68,8 +68,15 @@ read_schema_dependencies <- function(schema, children, parent, v8) {
   extra <- setdiff(find_schema_dependencies(schema, v8),
                    names(children))
 
+  ## Remove relative references
+  extra <- grep("^#", extra, invert = TRUE, value = TRUE)
+
   if (length(extra) == 0L) {
     return(NULL)
+  }
+
+  if (any(grepl("://", extra))) {
+    stop("Don't yet support protocol-based sub schemas")
   }
 
   for (p in extra) {

--- a/R/util.R
+++ b/R/util.R
@@ -49,3 +49,8 @@ vcapply <- function(X, FUN, ...) {
   vapply(X, FUN, character(1), ...)
 
 }
+
+
+squote <- function(x) {
+  sprintf("'%s'", x)
+}

--- a/R/util.R
+++ b/R/util.R
@@ -30,3 +30,22 @@ random_id <- function() {
 `%||%` <- function(a, b) {
   if (is.null(a)) b else a
 }
+
+
+
+with_dir <- function(path, code) {
+  owd <- setwd(path)
+  on.exit(setwd(owd))
+  force(code)
+}
+
+
+vlapply <- function(X, FUN, ...) {
+  vapply(X, FUN, logical(1), ...)
+}
+
+
+vcapply <- function(X, FUN, ...) {
+  vapply(X, FUN, character(1), ...)
+
+}

--- a/R/util.R
+++ b/R/util.R
@@ -54,3 +54,9 @@ vcapply <- function(X, FUN, ...) {
 squote <- function(x) {
   sprintf("'%s'", x)
 }
+
+
+set_names <- function(x, nms) {
+  names(x) <- nms
+  x
+}

--- a/R/validate.R
+++ b/R/validate.R
@@ -45,7 +45,7 @@ json_validator <- function(schema, engine = "imjv", reference = NULL) {
 
 ##' Validate a single json against a schema.  This is a convenience
 ##' wrapper around \code{json_validator(schema)(json)}.  See
-##' \code{\link{json_Validator}} for further details.
+##' \code{\link{json_validator}} for further details.
 ##'
 ##' @title Validate a json file
 ##'

--- a/R/validate.R
+++ b/R/validate.R
@@ -16,7 +16,21 @@
 ##'   'Hello' object, one could pass "#/definitions/Hello" and the validator
 ##'   would check that the json is a valid "Hello" object. Only available if 
 ##'   \code{engine = 'ajv'}.
-##'   
+##'
+##' @section Using multiple files:
+##'
+##' Multiple files are supported.  You can have a schema that
+##'   references a file \code{cbild.json} using \code{{"$ref":
+##'   "child.json"}} - in this case if \code{child.json} includes an
+##'   \code{id} or \code{$id} element it will be silently dropped and
+##'   the filename used to reference the schema will be used as the
+##'   schema id.
+##'
+##' The support is currently quite limited - it will not (yet) read
+##'   sub-child schemas relative to child schema \code{$id} url, and
+##'   does not suppoort reading from URLs (only local files are
+##'   supoported).
+##'
 ##' @export
 ##' @example man-roxygen/example-json_validator.R
 json_validator <- function(schema, engine = "imjv", reference = NULL) {
@@ -30,7 +44,8 @@ json_validator <- function(schema, engine = "imjv", reference = NULL) {
 
 
 ##' Validate a single json against a schema.  This is a convenience
-##' wrapper around \code{json_validator(schema)(json)}
+##' wrapper around \code{json_validator(schema)(json)}.  See
+##' \code{\link{json_Validator}} for further details.
 ##'
 ##' @title Validate a json file
 ##'

--- a/R/validate.R
+++ b/R/validate.R
@@ -65,6 +65,16 @@ json_validator_imjv <- function(schema, v8) {
   name <- random_id()
   meta_schema_version <- schema$meta_schema_version %||% "draft-04"
 
+  if (meta_schema_version != "draft-04") {
+    stop(sprintf(
+      "meta schema version '%s' is only supported with engine 'ajv'",
+      meta_schema_version))
+  }
+
+  if (length(schema$dependencies) > 0L) {
+    stop("Schema references are only supported with engine 'ajv'")
+  }
+
   v8$call("imjv_create", name, meta_schema_version, V8::JS(schema$schema))
 
   ret <- function(json, verbose = FALSE, greedy = FALSE, error = FALSE) {
@@ -89,9 +99,9 @@ json_validator_ajv <- function(schema, v8, reference) {
   if (is.null(reference)) {
     reference <- V8::JS("null")
   }
-
+  dependencies <- V8::JS(schema$dependencies %||% "null")
   v8$call("ajv_create", name, meta_schema_version, V8::JS(schema$schema),
-          reference)
+          dependencies, reference)
 
   ret <- function(json, verbose = FALSE, greedy = FALSE, error = FALSE) {
     res <- v8$call("ajv_call", name, V8::JS(get_string(json)),

--- a/R/validate.R
+++ b/R/validate.R
@@ -20,13 +20,10 @@
 ##' @export
 ##' @example man-roxygen/example-json_validator.R
 json_validator <- function(schema, engine = "imjv", reference = NULL) {
-  if (!is.null(reference) && engine != 'ajv') {
-    stop("subschema validation only supported with engine 'ajv'")
-  }
   v8 <- env$ct
   schema <- read_schema(schema, v8)
   switch(engine,
-         imjv = json_validator_imjv(schema, v8),
+         imjv = json_validator_imjv(schema, v8, reference),
          ajv = json_validator_ajv(schema, v8, reference),
          stop(sprintf("Unknown engine '%s'", engine)))
 }
@@ -61,9 +58,13 @@ json_validate <- function(json, schema, verbose = FALSE, greedy = FALSE,
 }
 
 
-json_validator_imjv <- function(schema, v8) {
+json_validator_imjv <- function(schema, v8, reference) {
   name <- random_id()
   meta_schema_version <- schema$meta_schema_version %||% "draft-04"
+
+  if (!is.null(reference)) {
+    stop("subschema validation only supported with engine 'ajv'")
+  }
 
   if (meta_schema_version != "draft-04") {
     stop(sprintf(

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -38,9 +38,9 @@ global.ajv_create = function(key, meta_schema_version, schema, dependencies,
                              reference) {
     var ret = ajv_create_object(meta_schema_version);
 
-    // no fat arrow support here unfortunately...
     if (dependencies) {
-        dependencies.forEach(function(x) {ret.addSchema(x.value, x.id)});
+        dependencies.forEach(
+            function(x) {ret.addSchema(drop_id(x.value), x.id)});
     }
 
     if (reference === null) {
@@ -49,6 +49,12 @@ global.ajv_create = function(key, meta_schema_version, schema, dependencies,
         ret = ret.addSchema(schema).getSchema(reference);
     }
     validators["ajv"][key] = ret;
+}
+
+global.drop_id = function(x) {
+    delete x.id;
+    delete x.$id;
+    return x;
 }
 
 global.imjv_create = function(key, meta_schema_version, schema) {

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -100,12 +100,15 @@ global.find_reference = function(x) {
             //
             // > You will always use $ref as the only key in an
             // > object: any other keys you put there will be ignored
-            // > by the validator.
+            // > by the validator
+            //
+            // though this turns not to be true empirically...
             if ("$ref" in x) {
                 deps.push(x["$ref"]);
-            } else {
-                Object.values(x).forEach(f);
             }
+            // Would be nicer with Object.values but that does not
+            // work on travis apparently.
+            Object.keys(x).forEach(function(k) {f(x[k]);});
         }
     }
     f(x);

--- a/js/in.js
+++ b/js/in.js
@@ -98,12 +98,13 @@ global.find_reference = function(x) {
             //
             // > You will always use $ref as the only key in an
             // > object: any other keys you put there will be ignored
-            // > by the validator.
+            // > by the validator
+            //
+            // though this turns not to be true empirically...
             if ("$ref" in x) {
                 deps.push(x["$ref"]);
-            } else {
-                Object.values(x).forEach(f);
             }
+            Object.values(x).forEach(f);
         }
     }
     f(x);

--- a/js/in.js
+++ b/js/in.js
@@ -32,8 +32,15 @@ global.ajv_create_object = function(meta_schema_version) {
 }
 
 // TODO: we can push greedy into here
-global.ajv_create = function(key, meta_schema_version, schema, reference) {
+global.ajv_create = function(key, meta_schema_version, schema, dependencies,
+                             reference) {
     var ret = ajv_create_object(meta_schema_version);
+
+    // no fat arrow support here unfortunately...
+    if (dependencies) {
+        dependencies.forEach(function(x) {ret.addSchema(x.value, x.id)});
+    }
+
     if (reference === null) {
         ret = ret.compile(schema);
     } else {
@@ -76,4 +83,29 @@ global.get_meta_schema_version = function(schema) {
 global.validator_stats = function() {
     return {"imjv": Object.keys(validators["imjv"]).length,
             "ajv": Object.keys(validators["ajv"]).length};
+}
+
+global.find_reference = function(x) {
+    deps = []
+
+    f = function(x) {
+        if (Array.isArray(x)) {
+            // need to descend into arrays as they're used for things
+            // like oneOf or anyOf constructs.
+            x.forEach(f);
+        } else if (typeof(x) === "object") {
+            // From the JSON schema docs:
+            //
+            // > You will always use $ref as the only key in an
+            // > object: any other keys you put there will be ignored
+            // > by the validator.
+            if ("$ref" in x) {
+                deps.push(x["$ref"]);
+            } else {
+                Object.values(x).forEach(f);
+            }
+        }
+    }
+    f(x);
+    return deps;
 }

--- a/js/in.js
+++ b/js/in.js
@@ -36,9 +36,9 @@ global.ajv_create = function(key, meta_schema_version, schema, dependencies,
                              reference) {
     var ret = ajv_create_object(meta_schema_version);
 
-    // no fat arrow support here unfortunately...
     if (dependencies) {
-        dependencies.forEach(function(x) {ret.addSchema(x.value, x.id)});
+        dependencies.forEach(
+            function(x) {ret.addSchema(drop_id(x.value), x.id)});
     }
 
     if (reference === null) {
@@ -47,6 +47,12 @@ global.ajv_create = function(key, meta_schema_version, schema, dependencies,
         ret = ret.addSchema(schema).getSchema(reference);
     }
     validators["ajv"][key] = ret;
+}
+
+global.drop_id = function(x) {
+    delete x.id;
+    delete x.$id;
+    return x;
 }
 
 global.imjv_create = function(key, meta_schema_version, schema) {

--- a/js/in.js
+++ b/js/in.js
@@ -104,7 +104,9 @@ global.find_reference = function(x) {
             if ("$ref" in x) {
                 deps.push(x["$ref"]);
             }
-            Object.values(x).forEach(f);
+            // Would be nicer with Object.values but that does not
+            // work on travis apparently.
+            Object.keys(x).forEach(function(k) {f(x[k]);});
         }
     }
     f(x);

--- a/js/prepare
+++ b/js/prepare
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 HERE=$(dirname $0)
 cd $HERE
 

--- a/man/json_validate.Rd
+++ b/man/json_validate.Rd
@@ -38,7 +38,8 @@ would check that the json is a valid "Hello" object. Only available if
 }
 \description{
 Validate a single json against a schema.  This is a convenience
-wrapper around \code{json_validator(schema)(json)}
+wrapper around \code{json_validator(schema)(json)}.  See
+\code{\link{json_Validator}} for further details.
 }
 \examples{
 # A simple schema example:

--- a/man/json_validate.Rd
+++ b/man/json_validate.Rd
@@ -39,7 +39,7 @@ would check that the json is a valid "Hello" object. Only available if
 \description{
 Validate a single json against a schema.  This is a convenience
 wrapper around \code{json_validator(schema)(json)}.  See
-\code{\link{json_Validator}} for further details.
+\code{\link{json_validator}} for further details.
 }
 \examples{
 # A simple schema example:

--- a/man/json_validator.Rd
+++ b/man/json_validator.Rd
@@ -25,6 +25,22 @@ would check that the json is a valid "Hello" object. Only available if
 \description{
 Create a validator that can validate multiple json files.
 }
+\section{Using multiple files}{
+
+
+Multiple files are supported.  You can have a schema that
+  references a file \code{cbild.json} using \code{{"$ref":
+  "child.json"}} - in this case if \code{child.json} includes an
+  \code{id} or \code{$id} element it will be silently dropped and
+  the filename used to reference the schema will be used as the
+  schema id.
+
+The support is currently quite limited - it will not (yet) read
+  sub-child schemas relative to child schema \code{$id} url, and
+  does not suppoort reading from URLs (only local files are
+  supoported).
+}
+
 \examples{
 # A simple schema example:
 schema <- '{

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -1,0 +1,66 @@
+context("read")
+
+test_that("can't read empty input", {
+  expect_error(read_schema(NULL, env$ct),
+               "zero length input")
+  expect_error(read_schema(character(0), env$ct),
+               "zero length input")
+})
+
+
+test_that("must read character input", {
+  expect_error(read_schema(1, env$ct),
+               "Expected a character vector")
+})
+
+
+test_that("sensible error on missing files", {
+  a <- c(
+    '{',
+    '"$ref": "b.json"',
+    '}')
+  b <- c(
+    '{',
+    '"$ref": "c.json"',
+    '}')
+  c <- c(
+    '{',
+    '    "type": "string"',
+    '}')
+  path <- tempfile()
+  dir.create(path)
+  writeLines(a, file.path(path, "a.json"))
+  writeLines(b, file.path(path, "b.json"))
+  expect_error(
+    read_schema(file.path(path, "b.json"), env$ct),
+    "While reading 'b.json'\nDid not find schema file 'c.json'",
+    class = "jsonvalidate_read_error")
+  expect_error(
+    read_schema(file.path(path, "a.json"), env$ct),
+    "While reading 'a.json' > 'b.json'\nDid not find schema file 'c.json'",
+    class = "jsonvalidate_read_error")
+})
+
+
+test_that("Read recursive schema", {
+  sexpression <- c(
+    '{',
+    '  "oneOf": [',
+    '  {"type": "string"},',
+    '  {"type": "number"},',
+    '  {"type": "array", "items": {"$ref": "sexpression.json"}}',
+    ']}')
+
+  path <- tempfile()
+  dir.create(path)
+  p <- file.path(path, "sexpression.json")
+  writeLines(sexpression, p)
+  dat <- read_schema(p, env$ct)
+  expect_equal(length(dat$dependencies), 1)
+  expect_equal(jsonlite::fromJSON(dat$dependencies)$id, "sexpression.json")
+
+  v <- json_validator(p, engine = "ajv")
+  expect_false(v("{}"))
+  expect_true(v('["a"]'))
+  expect_true(v('["a", ["b", "c", 3]]'))
+})

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -146,3 +146,24 @@ test_that("Sensible reporting on syntax error", {
     "While reading 'parent.json' > 'child.json'",
     class = "jsonvalidate_read_error")
 })
+
+
+test_that("schema string vs filename detection", {
+  expect_false(read_schema_is_filename("''"))
+  expect_false(read_schema_is_filename('""'))
+  expect_false(read_schema_is_filename('{}'))
+  expect_true(read_schema_is_filename('/foo/bar.json'))
+  expect_true(read_schema_is_filename('bar.json'))
+  expect_true(read_schema_is_filename('bar'))
+
+  expect_false(read_schema_is_filename(character()))
+  expect_false(read_schema_is_filename(c("a", "b")))
+  expect_false(read_schema_is_filename(I('/foo/bar.json')))
+})
+
+
+test_that("sensible error if reading missing schema", {
+  expect_error(
+    read_schema("/file/that/does/not/exist.json"),
+    "Schema '/file/that/does/not/exist.json' looks like a filename but")
+})

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -258,3 +258,32 @@ test_that("Simple file references work", {
   expect_false(v("{}"))
   expect_true(v('{"hello": "world"}'))
 })
+
+
+test_that("Referenced schemas have their ids replaced", {
+  parent <- c(
+    '{',
+    '    "type": "object",',
+    '    "properties": {',
+    '        "hello": {',
+    '            "$ref": "child.json"',
+    '        }',
+    '    },',
+    '    "required": ["hello"],',
+    '    "additionalProperties": false',
+    '}')
+  child <- c(
+    '{',
+    '    "id": "child",',
+    '    "type": "string"',
+    '}')
+  path <- tempfile()
+  dir.create(path)
+  writeLines(parent, file.path(path, "parent.json"))
+  writeLines(child, file.path(path, "child.json"))
+
+  expect_silent(
+    v <- json_validator(file.path(path, "parent.json"), engine = "ajv"))
+  expect_false(v("{}"))
+  expect_true(v('{"hello": "world"}'))
+})

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -180,6 +180,22 @@ test_that("can't use invalid engines", {
 })
 
 
+test_that("can't use new schema versions with imjv", {
+  schema <- "{
+    '$schema': 'http://json-schema.org/draft-07/schema#',
+    'type': 'object',
+    'properties': {
+      'a': {
+        'const': 'foo'
+      }
+    }
+  }"
+  expect_error(
+    json_validator(schema, engine = "imjv"),
+    "meta schema version 'draft-07' is only supported with engine 'ajv'")
+})
+
+
 test_that("package support", {
   res <- prepare_js()
   expect_is(res, "V8")

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -189,3 +189,30 @@ test_that("package support", {
   expect_equal(s$imjv, 0)
   expect_equal(s$ajv, 0)
 })
+
+
+test_that("Simple file references work", {
+  parent <- c(
+    '{',
+    '    "type": "object",',
+    '    "properties": {',
+    '        "hello": {',
+    '            "$ref": "child.json"',
+    '        }',
+    '    },',
+    '    "required": ["hello"],',
+    '    "additionalProperties": false',
+    '}')
+  child <- c(
+    '{',
+    '    "type": "string"',
+    '}')
+  path <- tempfile()
+  dir.create(path)
+  writeLines(parent, file.path(path, "parent.json"))
+  writeLines(child, file.path(path, "child.json"))
+
+  v <- json_validator(file.path(path, "parent.json"), engine = "ajv")
+  expect_false(v("{}"))
+  expect_true(v('{"hello": "world"}'))
+})

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -173,6 +173,32 @@ test_that("can't use subschema reference with imjv", {
                "subschema validation only supported with engine 'ajv'")
 })
 
+test_that("can't use nested schemas with imjv", {
+  parent <- c(
+    '{',
+    '    "type": "object",',
+    '    "properties": {',
+    '        "hello": {',
+    '            "$ref": "child.json"',
+    '        }',
+    '    },',
+    '    "required": ["hello"],',
+    '    "additionalProperties": false',
+    '}')
+  child <- c(
+    '{',
+    '    "type": "string"',
+    '}')
+  path <- tempfile()
+  dir.create(path)
+  writeLines(parent, file.path(path, "parent.json"))
+  writeLines(child, file.path(path, "child.json"))
+
+  expect_error(
+    json_validator(file.path(path, "parent.json"), engine = "imjv"),
+    "Schema references are only supported with engine 'ajv'")
+})
+
 
 test_that("can't use invalid engines", {
   expect_error(json_validator("{}", engine = "magic"),


### PR DESCRIPTION
This PR will introduce support for schemas that reference other files, for example, trivially:

`a.json`:
```json
{
  "$ref": "a.json"
}
```

`b.json`:
```json
{
  "type": "string"
}
```

This is only supported for the `ajv` engine and will error if used with the `imjv` engine (I've not checked reverse dependencies here to see if that impacts the on-CRAN uses but I hope not because otherwise their packages are not validating the expected schema).

There is more to do here eventually - for example, we don't support loading external schemas from URIs.  Doing the latter requires moving the root at which relative paths are resolved.  We should also be resolving relative paths relative to the `$id` element of the schema if present.  But I think that can all be added on top of this once we're happy with how it worked.

My original attempt at doing this had the `$ref` extraction done in R using `jsonlite` but I have walked away from doing that because the `jsonlite` parser is slightly different to the behaviour of passing the json into `V8` (notably the latter allowed unquoted json entries).  This change broke all the tests, but also made me concerned that it would break existing use.  So the `in.js` file more logic now.

Fixes #20 