### PR TITLE
Fixed issue with draft-04 schema verification error

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -41,14 +41,14 @@
             "integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg=="
         },
         "ajv": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-            "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
             "requires": {
                 "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
                 "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.1"
+                "uri-js": "^4.2.2"
             }
         },
         "asn1.js": {

--- a/js/package.json
+++ b/js/package.json
@@ -17,7 +17,7 @@
         "url": "https://github.com/ropensci/jsonvalidate/issues"
     },
     "dependencies": {
-        "ajv": "^6.5.2",
+        "ajv": "^6.10.2",
         "browserify": "^16.5.0",
         "is-my-json-valid": "^2.17.2"
     },


### PR DESCRIPTION
This PR fixes issue #32 by upgrading the version of `ajv` used by `jsonvalidate` to a more recent version. The more recent version includes an updated version of the draft-04 schema that matches the version currently available [online](http://json-schema.org/draft-04/schema).