### PR TITLE
Add support for referencing definitions in other schema files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jsonvalidate
 Title: Validate 'JSON' Schema
-Version: 1.2.2
+Version: 1.2.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com"),
     person("Alicia", "Schep", role = "ctb"),
@@ -24,6 +24,6 @@ Suggests:
     jsonlite,
     rmarkdown,
     testthat
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## jsonvalidate 1.2.3
+
+* Schemas can use references to other files with JSON pointers i.e. schemas can reference parts of other files e.g. `definitions.json#/definitions/hello`
+
 ## jsonvalidate 1.?.?
 
 * JSON can be validated against a subschema (#18, #19, @AliciaSchep)

--- a/R/read.R
+++ b/R/read.R
@@ -79,6 +79,11 @@ read_schema_dependencies <- function(schema, children, parent, v8) {
     stop("Don't yet support protocol-based sub schemas")
   }
 
+  if (any(grepl("#/", extra))) {
+    split <- strsplit(extra, "#/")
+    extra <- lapply(split, "[[", 1)
+  }
+
   for (p in extra) {
     ## Mark name as one that we will not descend further with
     children[[p]] <- NULL

--- a/R/validate.R
+++ b/R/validate.R
@@ -9,18 +9,18 @@
 ##'   "imjv" (the default; which uses "is-my-json-valid") and "ajv"
 ##'   (Another JSON Schema Validator).  The latter supports more
 ##'   recent json schema features.
-##'   
-##' @param reference Reference within schema to use for validating against a 
+##'
+##' @param reference Reference within schema to use for validating against a
 ##'   sub-schema instead of the full schema passed in. For example
-##'   if the schema has a 'definitions' list including a definition for a 
+##'   if the schema has a 'definitions' list including a definition for a
 ##'   'Hello' object, one could pass "#/definitions/Hello" and the validator
-##'   would check that the json is a valid "Hello" object. Only available if 
+##'   would check that the json is a valid "Hello" object. Only available if
 ##'   \code{engine = 'ajv'}.
 ##'
 ##' @section Using multiple files:
 ##'
 ##' Multiple files are supported.  You can have a schema that
-##'   references a file \code{cbild.json} using \code{{"$ref":
+##'   references a file \code{child.json} using \code{{"$ref":
 ##'   "child.json"}} - in this case if \code{child.json} includes an
 ##'   \code{id} or \code{$id} element it will be silently dropped and
 ##'   the filename used to reference the schema will be used as the
@@ -69,7 +69,7 @@ json_validator <- function(schema, engine = "imjv", reference = NULL) {
 ##'   \href{https://www.npmjs.com/package/jsonpath}{jsonpath} syntax,
 ##'   but for now this must be the name of an element within
 ##'   \code{json}.  See the examples for more details.
-##'   
+##'
 ##' @export
 ##' @example man-roxygen/example-json_validate.R
 json_validate <- function(json, schema, verbose = FALSE, greedy = FALSE,
@@ -126,9 +126,12 @@ json_validator_ajv <- function(schema, v8, reference) {
   if (is.null(reference)) {
     reference <- V8::JS("null")
   }
+  if (is.null(schema$filename)) {
+    schema$filename <- V8::JS("null")
+  }
   dependencies <- V8::JS(schema$dependencies %||% "null")
   v8$call("ajv_create", name, meta_schema_version, V8::JS(schema$schema),
-          dependencies, reference)
+          schema$filename, dependencies, reference)
 
   ret <- function(json, verbose = FALSE, greedy = FALSE, error = FALSE,
                   query = NULL) {

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -34,19 +34,25 @@ global.ajv_create_object = function(meta_schema_version) {
 }
 
 // TODO: we can push greedy into here
-global.ajv_create = function(key, meta_schema_version, schema, dependencies,
-                             reference) {
+global.ajv_create = function(key, meta_schema_version, schema, filename,
+                             dependencies, reference) {
     var ret = ajv_create_object(meta_schema_version);
 
     if (dependencies) {
         dependencies.forEach(
-            function(x) {ret.addSchema(drop_id(x.value), x.id)});
+            function(x) {
+                // Avoid adding a dependency and then adding it again as the
+                // main schema. This might occur if we have recusive references.
+                if (x.id !== filename) {
+                    ret.addSchema(drop_id(x.value), x.id)
+                }
+            });
     }
 
     if (reference === null) {
-        ret = ret.compile(schema);
+        ret = ret.addSchema(drop_id(schema), filename).getSchema(filename);
     } else {
-        ret = ret.addSchema(schema).getSchema(reference);
+        ret = ret.addSchema(drop_id(schema), filename).getSchema(reference);
     }
     validators["ajv"][key] = ret;
 }

--- a/man/json_validate.Rd
+++ b/man/json_validate.Rd
@@ -4,8 +4,16 @@
 \alias{json_validate}
 \title{Validate a json file}
 \usage{
-json_validate(json, schema, verbose = FALSE, greedy = FALSE,
-  error = FALSE, engine = "imjv", reference = NULL, query = NULL)
+json_validate(
+  json,
+  schema,
+  verbose = FALSE,
+  greedy = FALSE,
+  error = FALSE,
+  engine = "imjv",
+  reference = NULL,
+  query = NULL
+)
 }
 \arguments{
 \item{json}{Contents of a json object, or a filename containing
@@ -29,11 +37,11 @@ only for the side-effect of an error on failure, like
 (Another JSON Schema Validator).  The latter supports more
 recent json schema features.}
 
-\item{reference}{Reference within schema to use for validating against a 
+\item{reference}{Reference within schema to use for validating against a
 sub-schema instead of the full schema passed in. For example
-if the schema has a 'definitions' list including a definition for a 
+if the schema has a 'definitions' list including a definition for a
 'Hello' object, one could pass "#/definitions/Hello" and the validator
-would check that the json is a valid "Hello" object. Only available if 
+would check that the json is a valid "Hello" object. Only available if
 \code{engine = 'ajv'}.}
 
 \item{query}{A string indicating a component of the data to
@@ -52,7 +60,7 @@ wrapper around \code{json_validator(schema)(json)}.  See
 schema <- '{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Product",
-    "description": "A product from Acme\\'s catalog",
+    "description": "A product from Acme\'s catalog",
     "type": "object",
     "properties": {
         "id": {

--- a/man/json_validator.Rd
+++ b/man/json_validator.Rd
@@ -15,11 +15,11 @@ containing a schema.}
 (Another JSON Schema Validator).  The latter supports more
 recent json schema features.}
 
-\item{reference}{Reference within schema to use for validating against a 
+\item{reference}{Reference within schema to use for validating against a
 sub-schema instead of the full schema passed in. For example
-if the schema has a 'definitions' list including a definition for a 
+if the schema has a 'definitions' list including a definition for a
 'Hello' object, one could pass "#/definitions/Hello" and the validator
-would check that the json is a valid "Hello" object. Only available if 
+would check that the json is a valid "Hello" object. Only available if
 \code{engine = 'ajv'}.}
 }
 \description{
@@ -29,7 +29,7 @@ Create a validator that can validate multiple json files.
 
 
 Multiple files are supported.  You can have a schema that
-  references a file \code{cbild.json} using \code{{"$ref":
+  references a file \code{child.json} using \code{{"$ref":
   "child.json"}} - in this case if \code{child.json} includes an
   \code{id} or \code{$id} element it will be silently dropped and
   the filename used to reference the schema will be used as the
@@ -46,7 +46,7 @@ The support is currently quite limited - it will not (yet) read
 schema <- '{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Product",
-    "description": "A product from Acme\\'s catalog",
+    "description": "A product from Acme\'s catalog",
     "type": "object",
     "properties": {
         "id": {

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -167,3 +167,25 @@ test_that("sensible error if reading missing schema", {
     read_schema("/file/that/does/not/exist.json"),
     "Schema '/file/that/does/not/exist.json' looks like a filename but")
 })
+
+test_that("can reference subsets of other schema", {
+  a <- c(
+    '{',
+    '"$ref": "b.json#/definitions/b"',
+    '}')
+  b <- c(
+    '{',
+    '    "definitions": {',
+    '        "b": {',
+    '            "type": "string"',
+    '        }',
+    '    }',
+    '}')
+  path <- tempfile()
+  dir.create(path)
+  writeLines(a, file.path(path, "a.json"))
+  writeLines(b, file.path(path, "b.json"))
+  schema <- read_schema(file.path(path, "a.json"), env$ct)
+  expect_equal(length(schema$dependencies), 1)
+  expect_equal(jsonlite::fromJSON(schema$dependencies)$id, "b.json")
+})


### PR DESCRIPTION
This PR will
* Add support for using JSON pointers in schema references e.g. can now have `"$ref": "definitions.json#/definitions/hello"`
* Registers main schema with filename as the ID - this is to avoid issues seen in  [biocompute with URLs as ids](https://github.com/sbg/biocompute/blob/master/inst/schemas/1.3.0-alpha/extension_domain/scm_extension.json#L3) failing to construct validator object

Should address #38 

I've validated that this doesn't break hintr tests. And it works with `biocompute` if they switch to ajv and we remove this line https://github.com/sbg/biocompute/blob/master/inst/schemas/1.3.0-alpha/extension_domain/scm_extension.json#L39 which I think is badly formatted for ajv anyway see https://ajv.js.org/guide/formats.html#string-formats