### PR TITLE
Alternative approach to compatibility

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - master
+      - mrc-2476
 
 name: R-CMD-check
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - master
+      - mrc-2476
 
 name: test-coverage
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Suggests:
     knitr,
     jsonlite,
     rmarkdown,
-    testthat
+    testthat,
+    withr
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,7 @@ Title: Validate 'JSON' Schema
 Version: 1.3.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com"),
+    person("Rob", "Ashton", role = "aut"),
     person("Alicia", "Schep", role = "ctb"),
     person("Ian", "Lyttle", role = "ctb"),
     person("Kara", "Woo", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,6 @@
 
 * Upgrade to ajv version 8.5.0
 * Add arg `strict` to `json_validate` and `json_validator` to allow evaluating schema in strict mode for ajv only. This is off (`FALSE`) by default to use permissive behaviour detailed in JSON schema
-* Use ajv as default validation engine if schema version explicitly set to > draft-04
 
 ## jsonvalidate 1.2.3
 

--- a/R/read.R
+++ b/R/read.R
@@ -114,12 +114,6 @@ read_meta_schema_version <- function(schema, v8) {
                   "(draft-\\d{2}|draft/\\d{4}-\\d{2})/schema#*$")
   version <- gsub(regex, "\\1", meta_schema)
 
-  versions_legal <- c("draft-04", "draft-06", "draft-07", "draft/2019-09",
-                      "draft/2020-12")
-  if (!(version %in% versions_legal)) {
-    stop(sprintf("Unknown meta schema version '%s'", version))
-  }
-
   version
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -60,3 +60,10 @@ set_names <- function(x, nms) {
   names(x) <- nms
   x
 }
+
+
+note_imjv <- function(msg) {
+  if (!isTRUE(getOption("jsonvalidate.no_note_imjv", FALSE))) {
+    message(msg)
+  }
+}

--- a/man/json_validator.Rd
+++ b/man/json_validator.Rd
@@ -32,6 +32,49 @@ https://ajv.js.org/strict-mode.html for details. Only available in
 \description{
 Create a validator that can validate multiple json files.
 }
+\section{Validation Engines}{
+
+
+We support two different json validation engines, \code{imjv}
+  ("is-my-json-valid") and \code{ajv} ("Another JSON
+  Validator"). \code{imjv} was the original validator included in
+  the package and remains the default for reasons of backward
+  compatibility. However, users are encouraged to migrate to
+  \code{ajv} as with it we support many more features, including
+  nested schemas that span multiple files, meta schema versions
+  later than draft-04, validating using a subschema, and
+  validating a subset of an input data object.
+
+If your schema uses these features we will print a message to
+  screen indicating that you should update. We do not use a
+  warning here as this will be disruptive to users. You can
+  disable the message by setting the option
+  \code{jsonvalidate.no_imjv_notice} to \code{TRUE}. Consider
+  using \code{withr::with_options} (or simply
+  \code{suppressMessages}) to scope this option if you want to
+  quieten it within code you do not control.
+
+Updating the engine should be simply a case of adding \code{engine
+  = "ajv"} to your \code{json_validator} or \code{json_validate}
+  calls, but you may see some issues when doing so.
+
+\itemize{
+\item Your json now fails validation: We've seen this where
+  schemas spanned several files and are silently ignored. By
+  including these, your data may now fail validation and you will
+  need to either fix the data or the schema.
+
+\item Your code depended on the exact payload returned by
+  \code{imjv}: If you are inspecting the error result and checking
+  numbers of errors, or even the columns used to describe the
+  errors, you will likely need to update your code to accommodate
+  the slightly different format of \code{ajv}
+
+\item Your schema is simply invalid: If you reference an invalid
+  metaschema for example, jsonvalidate will fail
+}
+}
+
 \section{Using multiple files}{
 
 

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -77,22 +77,6 @@ test_that("can't read external schemas", {
 })
 
 
-test_that("invalid schema version", {
-  schema <- "{
-    '$schema': 'http://json-schema.org/draft-99/schema#',
-    'type': 'object',
-    'properties': {
-      'a': {
-        'const': 'foo'
-      }
-    }
-  }"
-  expect_error(
-    read_schema(schema, env$ct),
-    "Unknown meta schema version 'draft-99'")
-})
-
-
 test_that("Conflicting schema versions", {
   a <- c(
     '{',

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -28,3 +28,17 @@ test_that("get_string passes along strings", {
   expect_equal(get_string("file_that_does_not_exist.json"),
                "file_that_does_not_exist.json")
 })
+
+
+test_that("control printing imjv notice", {
+  testthat::skip_if_not_installed("withr")
+  withr::with_options(
+    list(jsonvalidate.no_note_imjv = NULL),
+    expect_message(note_imjv("note"), "note"))
+  withr::with_options(
+    list(jsonvalidate.no_note_imjv = FALSE),
+    expect_message(note_imjv("note"), "note"))
+  withr::with_options(
+    list(jsonvalidate.no_note_imjv = TRUE),
+    expect_silent(note_imjv("note")))
+})


### PR DESCRIPTION
This approach to backward compatibility is more complete - we no longer try and get people using ajv but instead let them know they're missing out.

The imjv validator now (again) fairly silently passes where given new json schema versions and does not read nested schemas. Packages that on CRAN which rely on that behaviour are unaffected and we can upgrade the package. Once done we should follow up with dependencies though and let them know.

I've added a bit of docs to make the situation clear

See also https://github.com/ropensci/jsonvalidate/compare/master...mrc-2476-compat for net change against master

Fixes #38 