### PR TITLE
No longer share one context among many validators

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -19,18 +19,9 @@ get_string <- function(x, what = deparse(substitute(x))) {
 }
 
 
-## An alternative here would be to drag in ids which has a nice
-## random_id function.  This approach here is at least safe to seed
-## setting
-random_id <- function() {
-  basename(tempfile(""))
-}
-
-
 `%||%` <- function(a, b) {
   if (is.null(a)) b else a
 }
-
 
 
 with_dir <- function(path, code) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,15 +1,5 @@
-env <- new.env(parent = emptyenv())
-
-
-prepare_js <- function() {
+jsonvalidate_js <- function() {
   ct <- V8::v8()
   ct$source(system.file("bundle.js", package = "jsonvalidate"))
   ct
-}
-
-
-## This can't be reliably tested - it's called during package startup
-## and outside of covr's measurements.
-.onLoad <- function(libname, pkgname) {
-  env$ct <- prepare_js() # nocov
 }

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -9,9 +9,6 @@ global.addFormats = require('ajv-formats');
 
 global.imjv = require('is-my-json-valid');
 
-// Storage for validators so we can interact with them from R
-global.validators = {"imjv": {}, "ajv": {}};
-
 global.ajv_create_object = function(meta_schema_version, strict) {
     // Need to disable strict mode, otherwise we get warnings
     // about unknown schema entries in draft-04 (e.g., presence of
@@ -44,7 +41,7 @@ global.ajv_create_object = function(meta_schema_version, strict) {
 }
 
 // TODO: we can push greedy into here
-global.ajv_create = function(key, meta_schema_version, strict, schema,
+global.ajv_create = function(meta_schema_version, strict, schema,
                              filename, dependencies, reference) {
     var ret = ajv_create_object(meta_schema_version, strict);
 
@@ -64,7 +61,9 @@ global.ajv_create = function(key, meta_schema_version, strict, schema,
     } else {
         ret = ret.addSchema(drop_id(schema), filename).getSchema(reference);
     }
-    validators["ajv"][key] = ret;
+
+    // Save in the global scope so we can use this later from R
+    global.validator = ret;
 }
 
 global.drop_id = function(x) {
@@ -73,41 +72,29 @@ global.drop_id = function(x) {
     return x;
 }
 
-global.imjv_create = function(key, meta_schema_version, schema) {
+global.imjv_create = function(meta_schema_version, schema) {
     // https://github.com/mafintosh/is-my-json-valid/issues/160
     if (meta_schema_version != "draft-04") {
         throw new Error("Only draft-04 json schema is supported");
     }
-    var ret = imjv(schema);
-    validators["imjv"][key] = ret;
+    global.validator = imjv(schema);
 }
 
-global.ajv_call = function(key, value, errors, query) {
-    var validator = validators["ajv"][key];
+global.ajv_call = function(value, errors, query) {
     var success = validator(jsonpath_eval(value, query));
     var errors = (!success && errors ? validator.errors : null);
     return {"success": success, "errors": errors, "engine": "ajv"};
 }
 
-global.imjv_call = function(key, value, errors, greedy) {
-    var validator = validators["imjv"][key];
+global.imjv_call = function(value, errors, greedy) {
     var success = validator(value, {"greedy": greedy}, {"verbose": errors});
     var errors = (!success && errors ? validator.errors : null);
     return {"success": success, "errors": errors, "engine": "imjv"};
 }
 
-global.validator_delete = function(type, name) {
-    delete validators[type][name];
-}
-
 global.get_meta_schema_version = function(schema) {
     return schema.$schema;
 };
-
-global.validator_stats = function() {
-    return {"imjv": Object.keys(validators["imjv"]).length,
-            "ajv": Object.keys(validators["ajv"]).length};
-}
 
 global.find_reference = function(x) {
     deps = []

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -220,26 +220,16 @@ test_that("can't use new schema versions with imjv", {
       }
     }
   }"
-  schema <- read_schema(schema, env$ct)
+  ct <- jsonvalidate_js()
+  schema <- read_schema(schema, ct)
   withr::with_options(
     list(jsonvalidate.no_note_imjv = FALSE),
     expect_message(
-      v <- json_validator_imjv(schema, env$ct, NULL),
+      v <- json_validator_imjv(schema, ct, NULL),
       "meta schema version other than 'draft-04' is only supported with"))
   ## We incorrectly don't find this invalid, because imjv does not
   ## understand the const keyword.
   expect_true(v('{"a": "bar"}'))
-})
-
-
-test_that("package support", {
-  res <- prepare_js()
-  expect_s3_class(res, "V8")
-  expect_setequal(names(res$get("validators")),
-                  c("imjv", "ajv"))
-  s <- res$call("validator_stats")
-  expect_equal(s$imjv, 0)
-  expect_equal(s$ajv, 0)
 })
 
 
@@ -384,7 +374,8 @@ test_that("stray null values in a schema are ok", {
       }
     }
   }'
-  expect_error(read_schema(schema, env$ct), NA)
+  ct <- jsonvalidate_js()
+  expect_error(read_schema(schema, ct), NA)
 })
 
 


### PR DESCRIPTION
This is the same approach as taken in traduire, and I think simpler. I think with this we might be able to fix #6 more easily.

Closes #43 