### PR TITLE
More control over messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jsonvalidate
 Title: Validate 'JSON' Schema
-Version: 1.3.0
+Version: 1.3.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com"),
     person("Rob", "Ashton", role = "aut"),
@@ -25,7 +25,7 @@ Suggests:
     rmarkdown,
     testthat,
     withr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/R/util.R
+++ b/R/util.R
@@ -53,8 +53,20 @@ set_names <- function(x, nms) {
 }
 
 
-note_imjv <- function(msg) {
-  if (!isTRUE(getOption("jsonvalidate.no_note_imjv", FALSE))) {
+note_imjv <- function(msg, is_interactive = interactive()) {
+  ## no_note_imjv  interactive => outcome
+  ##         NULL         TRUE    message
+  ##         NULL        FALSE    silent
+  ##        FALSE        <any>    message
+  ##         TRUE        <any>    silent
+  no_note_imjv <- getOption("jsonvalidate.no_note_imjv")
+
+  if (is.null(no_note_imjv)) {
+    show <- is_interactive
+  } else {
+    show <- !no_note_imjv
+  }
+  if (show) {
     message(msg)
   }
 }

--- a/R/validate.R
+++ b/R/validate.R
@@ -13,13 +13,15 @@
 ##'   validating a subset of an input data object.
 ##'
 ##' If your schema uses these features we will print a message to
-##'   screen indicating that you should update. We do not use a
-##'   warning here as this will be disruptive to users. You can
-##'   disable the message by setting the option
-##'   `jsonvalidate.no_note_imjv` to `TRUE`. Consider
-##'   using [withr::with_options()] (or simply
-##'   [suppressMessages()]) to scope this option if you want to
-##'   quieten it within code you do not control.
+##'   screen indicating that you should update when running
+##'   interactively. We do not use a warning here as this will be
+##'   disruptive to users. You can disable the message by setting the
+##'   option `jsonvalidate.no_note_imjv` to `TRUE`. Consider using
+##'   [withr::with_options()] (or simply [suppressMessages()]) to
+##'   scope this option if you want to quieten it within code you do
+##'   not control.  Alternatively, setting the option
+##'   `jsonvalidate.no_note_imjv` to `FALSE` will print the message
+##'   even noninteractively.
 ##'
 ##' Updating the engine should be simply a case of adding `{engine
 ##'   = "ajv"` to your `json_validator` or `json_validate`

--- a/man/json_validator.Rd
+++ b/man/json_validator.Rd
@@ -46,13 +46,15 @@ later than draft-04, validating using a subschema, and
 validating a subset of an input data object.
 
 If your schema uses these features we will print a message to
-screen indicating that you should update. We do not use a
-warning here as this will be disruptive to users. You can
-disable the message by setting the option
-\code{jsonvalidate.no_note_imjv} to \code{TRUE}. Consider
-using \code{\link[withr:with_options]{withr::with_options()}} (or simply
-\code{\link[=suppressMessages]{suppressMessages()}}) to scope this option if you want to
-quieten it within code you do not control.
+screen indicating that you should update when running
+interactively. We do not use a warning here as this will be
+disruptive to users. You can disable the message by setting the
+option \code{jsonvalidate.no_note_imjv} to \code{TRUE}. Consider using
+\code{\link[withr:with_options]{withr::with_options()}} (or simply \code{\link[=suppressMessages]{suppressMessages()}}) to
+scope this option if you want to quieten it within code you do
+not control.  Alternatively, setting the option
+\code{jsonvalidate.no_note_imjv} to \code{FALSE} will print the message
+even noninteractively.
 
 Updating the engine should be simply a case of adding \verb{\{engine = "ajv"} to your \code{json_validator} or \code{json_validate}
 calls, but you may see some issues when doing so.

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -32,11 +32,20 @@ test_that("control printing imjv notice", {
   testthat::skip_if_not_installed("withr")
   withr::with_options(
     list(jsonvalidate.no_note_imjv = NULL),
-    expect_message(note_imjv("note"), "note"))
+    expect_message(note_imjv("note", TRUE), "note"))
   withr::with_options(
     list(jsonvalidate.no_note_imjv = FALSE),
-    expect_message(note_imjv("note"), "note"))
+    expect_message(note_imjv("note", TRUE), "note"))
   withr::with_options(
     list(jsonvalidate.no_note_imjv = TRUE),
-    expect_silent(note_imjv("note")))
+    expect_silent(note_imjv("note", TRUE)))
+  withr::with_options(
+    list(jsonvalidate.no_note_imjv = NULL),
+    expect_silent(note_imjv("note", FALSE)))
+  withr::with_options(
+    list(jsonvalidate.no_note_imjv = FALSE),
+    expect_message(note_imjv("note", FALSE), "note"))
+  withr::with_options(
+    list(jsonvalidate.no_note_imjv = TRUE),
+    expect_silent(note_imjv("note", TRUE)))
 })


### PR DESCRIPTION
This should fix the revdep failure in clinDataReview seen in #49

The code becomes a bit more complicated, but clinDataReview will pass non-interactively now, which is all we need

Passes on win builder: https://win-builder.r-project.org/6Nr4bhwt3feV/00check.log
All revdeps passing, so we could submit this version as a CRAN update

Fixes #49 