### PR TITLE
Issue 61: Supported nested schema references in subfolders

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ URL: https://docs.ropensci.org/jsonvalidate/,
     https://github.com/ropensci/jsonvalidate
 BugReports: https://github.com/ropensci/jsonvalidate/issues
 Imports:
-    R.utils,
     R6,
     V8
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ URL: https://docs.ropensci.org/jsonvalidate/,
     https://github.com/ropensci/jsonvalidate
 BugReports: https://github.com/ropensci/jsonvalidate/issues
 Imports:
+    R.utils,
     R6,
     V8
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jsonvalidate
 Title: Validate 'JSON' Schema
-Version: 1.4.0
+Version: 1.4.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com"),
     person("Rob", "Ashton", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# jsonvalidate 1.4.1
+
+* Add support for subfolders in nested schema references. (#61)
+
 # jsonvalidate 1.4.0
 
 * Support for safely serialising objects to json, guided by the schema, with new function `json_serialise`

--- a/R/read.R
+++ b/R/read.R
@@ -43,13 +43,13 @@ read_schema <- function(x, v8) {
 
 
 read_schema_filename <- function(filename, children, parent, v8) {
-  ## '$ref' path should be relative to schema ID so if parent is in a 
+  ## '$ref' path should be relative to schema ID so if parent is in a
   ## subdir we need to add the dir to the filename so it can be sourced
   file_path <- filename
-  if (path_includes_dir(parent[1]) && !R.utils::isAbsolutePath(file_path)) {
+  if (path_includes_dir(parent[1])) {
     file_path <- file.path(dirname(parent[1]), file_path)
   }
-  
+
   if (!file.exists(file_path)) {
     additional_msg <- ""
     if (file_path != filename) {
@@ -88,6 +88,12 @@ read_schema_dependencies <- function(schema, children, parent, v8) {
 
   if (any(grepl("://", extra))) {
     stop("Don't yet support protocol-based sub schemas")
+  }
+
+  if (any(is_absolute_path(extra))) {
+    abs <- extra[is_absolute_path(extra)]
+    abs <- paste0("'", paste(abs, collapse = "', '"), "'")
+    stop(sprintf("'$ref' paths must be relative, got absolute path(s) %s", abs))
   }
 
   if (any(grepl("#/", extra))) {

--- a/R/read.R
+++ b/R/read.R
@@ -43,15 +43,26 @@ read_schema <- function(x, v8) {
 
 
 read_schema_filename <- function(filename, children, parent, v8) {
-  if (!file.exists(filename)) {
-    stop(sprintf("Did not find schema file '%s'", filename))
+  ## '$ref' path should be relative to schema ID so if parent is in a 
+  ## subdir we need to add the dir to the filename so it can be sourced
+  file_path <- filename
+  if (path_includes_dir(parent[1])) {
+    file_path <- file.path(dirname(parent[1]), filename)
+  }
+  
+  if (!file.exists(file_path)) {
+    additional_msg <- ""
+    if (file_path != filename) {
+      additional_msg <- sprintf(" relative to '%s'", parent[1])
+    }
+    stop(sprintf("Did not find schema file '%s'%s", filename, additional_msg))
   }
 
-  schema <- paste(readLines(filename), collapse = "\n")
+  schema <- paste(readLines(file_path), collapse = "\n")
 
   meta_schema_version <- read_meta_schema_version(schema, v8)
-  read_schema_dependencies(schema, children, c(filename, parent), v8)
-  list(schema = schema, filename = filename,
+  read_schema_dependencies(schema, children, c(file_path, parent), v8)
+  list(schema = schema, filename = file_path,
        meta_schema_version = meta_schema_version)
 }
 
@@ -84,16 +95,16 @@ read_schema_dependencies <- function(schema, children, parent, v8) {
     extra <- lapply(split, "[[", 1)
   }
 
-  for (p in extra) {
+  for (ref in extra) {
     ## Mark name as one that we will not descend further with
-    children[[p]] <- NULL
+    children[[ref]] <- NULL
     ## I feel this should be easier to do with withCallingHandlers,
     ## but not getting anywhere there.
-    children[[p]] <- tryCatch(
-      read_schema_filename(p, children, parent, v8),
+    children[[ref]] <- tryCatch(
+      read_schema_filename(ref, children, parent, v8),
       error = function(e) {
         if (!inherits(e, "jsonvalidate_read_error")) {
-          chain <- paste(squote(c(rev(parent), p)), collapse = " > ")
+          chain <- paste(squote(c(rev(parent), ref)), collapse = " > ")
           e$message <- sprintf("While reading %s\n%s", chain, e$message)
           class(e) <- c("jsonvalidate_read_error", class(e))
           e$call <- NULL

--- a/R/read.R
+++ b/R/read.R
@@ -46,8 +46,8 @@ read_schema_filename <- function(filename, children, parent, v8) {
   ## '$ref' path should be relative to schema ID so if parent is in a 
   ## subdir we need to add the dir to the filename so it can be sourced
   file_path <- filename
-  if (path_includes_dir(parent[1])) {
-    file_path <- file.path(dirname(parent[1]), filename)
+  if (path_includes_dir(parent[1]) && !R.utils::isAbsolutePath(file_path)) {
+    file_path <- file.path(dirname(parent[1]), file_path)
   }
   
   if (!file.exists(file_path)) {

--- a/R/util.R
+++ b/R/util.R
@@ -75,3 +75,6 @@ path_includes_dir <- function(x) {
   !is.null(x) && basename(x) != x
 }
 
+is_absolute_path <- function(path) {
+  grepl("^(/|[A-Za-z]:)", path)
+}

--- a/R/util.R
+++ b/R/util.R
@@ -70,3 +70,7 @@ note_imjv <- function(msg, is_interactive = interactive()) {
     message(msg)
   }
 }
+
+path_includes_dir <- function(x) {
+  !is.null(x) && basename(x) != x
+}

--- a/R/util.R
+++ b/R/util.R
@@ -74,3 +74,4 @@ note_imjv <- function(msg, is_interactive = interactive()) {
 path_includes_dir <- function(x) {
   !is.null(x) && basename(x) != x
 }
+

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -49,3 +49,9 @@ test_that("control printing imjv notice", {
     list(jsonvalidate.no_note_imjv = TRUE),
     expect_silent(note_imjv("note", TRUE)))
 })
+
+test_that("can check if path includes dir", {
+  expect_false(path_includes_dir(NULL))
+  expect_false(path_includes_dir("file.json"))
+  expect_true(path_includes_dir("the/file.json"))
+})

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -388,10 +388,8 @@ test_that("absolute file references throw error", {
                      normalizePath(child_path1), normalizePath(child_path2)),
     parent_path)
 
-  msg <- sprintf(
-    "'$ref' paths must be relative, got absolute path(s) '%s', '%s'",
-    child_path1, child_path2)
-  expect_error(json_validator(parent_path, engine = "ajv"), msg, fixed = TRUE)
+  expect_error(json_validator(parent_path, engine = "ajv"),
+               "'\\$ref' paths must be relative, got absolute path\\(s\\)")
 })
 
 

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -389,13 +389,12 @@ test_that("absolute file references work", {
   dir.create(path)
   subdir <- file.path(path, "sub")
   dir.create(subdir)
-  child_path <- normalizePath(file.path(subdir, "child.json"), mustWork = FALSE)
+  child_path <- file.path(subdir, "child.json")
   writeLines(child, child_path)
-  middle_path <- normalizePath(file.path(subdir, "middle.json"),
-                               mustWork = FALSE)
-  writeLines(sprintf(middle, child_path), middle_path)
+  middle_path <- file.path(subdir, "middle.json")
+  writeLines(sprintf(middle, normalizePath(child_path)), middle_path)
   parent_path <- file.path(path, "parent.json")
-  writeLines(sprintf(parent, middle_path), parent_path)
+  writeLines(sprintf(parent, normalizePath(middle_path)), parent_path)
 
   v <- json_validator(parent_path, engine = "ajv")
   expect_false(v("{}"))

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -358,27 +358,19 @@ test_that("chained file references work", {
 })
 
 
-test_that("absolute file references work", {
+test_that("absolute file references throw error", {
   parent <- c(
-    '{',
-    '    "type": "object",',
-    '    "properties": {',
-    '        "hello": {',
-    '            "$ref": "%s"',
-    '        }',
-    '    },',
-    '    "required": ["hello"],',
-    '    "additionalProperties": false',
-    '}')
-  middle <- c(
     '{',
     '    "type": "object",',
     '    "properties": {',
     '        "greeting": {',
     '            "$ref": "%s"',
+    '        },',
+    '        "address": {',
+    '            "$ref": "%s"',
     '        }',
     '    },',
-    '    "required": ["greeting"],',
+    '    "required": ["greeting", "address"],',
     '    "additionalProperties": false',
     '}')
   child <- c(
@@ -387,19 +379,19 @@ test_that("absolute file references work", {
     '}')
   path <- tempfile()
   dir.create(path)
-  subdir <- file.path(path, "sub")
-  dir.create(subdir)
-  child_path <- file.path(subdir, "child.json")
-  writeLines(child, child_path)
-  middle_path <- file.path(subdir, "middle.json")
-  writeLines(sprintf(middle, normalizePath(child_path)), middle_path)
+  child_path1 <- file.path(path, "child1.json")
+  writeLines(child, child_path1)
+  child_path2 <- file.path(path, "child2.json")
+  writeLines(child, child_path2)
   parent_path <- file.path(path, "parent.json")
-  writeLines(sprintf(parent, normalizePath(middle_path)), parent_path)
+  writeLines(sprintf(paste0(parent, collapse = "\n"),
+                     normalizePath(child_path1), normalizePath(child_path2)),
+    parent_path)
 
-  v <- json_validator(parent_path, engine = "ajv")
-  expect_false(v("{}"))
-  expect_true(v('{"hello": { "greeting": "world"}}'))
-  expect_false(v('{"hello": { "greeting": 2}}'))
+  msg <- sprintf(
+    "'$ref' paths must be relative, got absolute path(s) '%s', '%s'",
+    child_path1, child_path2)
+  expect_error(json_validator(parent_path, engine = "ajv"), msg, fixed = TRUE)
 })
 
 
@@ -437,7 +429,7 @@ test_that("chained file references return useful error", {
   writeLines(parent, file.path(path, "parent.json"))
   writeLines(middle, file.path(subdir, "middle.json"))
   writeLines(child, file.path(subdir, "child.json"))
-  
+
   expect_error(
     json_validator(file.path(path, "parent.json"), engine = "ajv"),
     "Did not find schema file 'sub/child.json' relative to 'sub/middle.json'")

--- a/vignettes/jsonvalidate.Rmd
+++ b/vignettes/jsonvalidate.Rmd
@@ -274,7 +274,7 @@ writeLines(city_schema, city_path)
 jsonvalidate::json_validate(json, address_path, engine = "ajv")
 ```
 
-You can combine schemas in subdirectories. Note that the `$ref` path needs to be relative to the schema path.
+You can combine schemas in subdirectories. Note that the `$ref` path needs to be relative to the schema path. You can also use absolute paths in `$ref`.
 
 ```{r}
 user_schema = '{

--- a/vignettes/jsonvalidate.Rmd
+++ b/vignettes/jsonvalidate.Rmd
@@ -274,7 +274,7 @@ writeLines(city_schema, city_path)
 jsonvalidate::json_validate(json, address_path, engine = "ajv")
 ```
 
-You can combine schemas in subdirectories. Note that the `$ref` path needs to be relative to the schema path. You can also use absolute paths in `$ref`.
+You can combine schemas in subdirectories. Note that the `$ref` path needs to be relative to the schema path. You cannot use absolute paths in `$ref` and jsonvalidate will throw an error if you try to do so.
 
 ```{r}
 user_schema = '{

--- a/vignettes/jsonvalidate.Rmd
+++ b/vignettes/jsonvalidate.Rmd
@@ -228,3 +228,80 @@ v(json)
 ```
 
 While we do not intend on removing this old interface, new code should prefer both `jsonvalidate::json_schema` and the `ajv` engine.
+
+## Combining schemas
+
+You can combine schemas with `ajv` engine. You can reference definitions within one schema
+
+```{r}
+schema <- '{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "city": { "type": "string" }
+  },
+  "type": "object",
+  "properties": {
+    "city": { "$ref": "#/definitions/city" }
+  }
+}'
+json <- '{
+    "city": "Firenze"
+}'
+jsonvalidate::json_validate(json, schema, engine = "ajv")
+```
+You can reference schema from other files
+
+```{r}
+city_schema <- '{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "string",
+  "enum": ["Firenze"]
+}'
+address_schema <- '{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type":"object",
+  "properties": {
+    "city": { "$ref": "city.json" }
+  }
+}'
+
+path <- tempfile()
+dir.create(path)
+address_path <- file.path(path, "address.json")
+city_path <- file.path(path, "city.json")
+writeLines(address_schema, address_path)
+writeLines(city_schema, city_path)
+jsonvalidate::json_validate(json, address_path, engine = "ajv")
+```
+
+You can combine schemas in subdirectories. Note that the `$ref` path needs to be relative to the schema path.
+
+```{r}
+user_schema = '{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "required": ["address"],
+  "properties": {
+    "address": {
+      "$ref": "sub/address.json"
+    }
+  }
+}'
+
+json <- '{
+  "address": {
+    "city": "Firenze"
+  }
+}'
+
+path <- tempfile()
+subdir <- file.path(path, "sub")
+dir.create(subdir, showWarnings = FALSE, recursive = TRUE)
+city_path <- file.path(subdir, "city.json")
+address_path <- file.path(subdir, "address.json")
+user_path <- file.path(path, "schema.json")
+writeLines(city_schema, city_path)
+writeLines(address_schema, address_path)
+writeLines(user_schema, user_path)
+jsonvalidate::json_validate(json, user_path, engine = "ajv")
+```


### PR DESCRIPTION
This PR fixes #61. Note the path in the `$ref` must be relative to the current schema. So in the reprex for #61 where `address` references `city` schema as `sub-schemas/city` this needs to be just `city` as `address` is stored in `sub-schema` directory. I have updated the error message to hopefully make this clearer too.
