### PR TITLE
Better file detection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jsonvalidate
 Title: Validate 'JSON' Schema
-Version: 1.4.1
+Version: 1.4.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com"),
     person("Rob", "Ashton", role = "aut"),

--- a/R/util.R
+++ b/R/util.R
@@ -6,16 +6,22 @@ get_string <- function(x, what = deparse(substitute(x))) {
     stop(sprintf("Expected a character vector for %s", what))
   }
 
-  ## TODO: this will get looked at in the next PR as we need to force
-  ## filenames better; it's not possible with this approach to error
-  ## if a file is missed through a typo.
-  if (length(x) == 1 && file.exists(x)) {
+  if (refers_to_file(x)) {
     x <- paste(readLines(x), collapse = "\n")
   } else if (length(x) > 1L) {
     x <- paste(x, collapse = "\n")
   }
 
   x
+}
+
+
+refers_to_file <- function(x) {
+  ## good reasons not to be a file:
+  if (length(x) != 1 || inherits(x, "json") || grepl("{", x, fixed = TRUE)) {
+    return(FALSE)
+  }
+  file.exists(x)
 }
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -13,6 +13,17 @@ test_that("get_string reads files as a string", {
 })
 
 
+test_that("detect probable files", {
+  path <- tempfile()
+  expect_false(refers_to_file('{"a": 1}'))
+  expect_false(refers_to_file(structure("1", class = "json")))
+  expect_false(refers_to_file(c("a", "b")))
+  expect_false(refers_to_file(path))
+  writeLines(c("some", "test"), path)
+  expect_true(refers_to_file(path))
+})
+
+
 test_that("get_string concatenates character vectors", {
   expect_equal(get_string(c("some", "text")),
                "some\ntext")


### PR DESCRIPTION
This is because we were getting, sometimes, a warning when the json being checked against a file was > 4000 bytes from file.exists. So I've added a few short circuits that should work reasonably well I think