### PR TITLE
Allow reading from files with no trailing newlines.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -7,7 +7,7 @@ get_string <- function(x, what = deparse(substitute(x))) {
   }
 
   if (refers_to_file(x)) {
-    x <- paste(readLines(x), collapse = "\n")
+    x <- paste(readLines(x, warn = FALSE), collapse = "\n")
   } else if (length(x) > 1L) {
     x <- paste(x, collapse = "\n")
   }

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -66,3 +66,14 @@ test_that("can check if path includes dir", {
   expect_false(path_includes_dir("file.json"))
   expect_true(path_includes_dir("the/file.json"))
 })
+
+test_that("can read file with no trailing newline", {
+  path <- tempfile()
+  writeLines("12345678", path, sep="")
+
+  # Check that we wrote just what we wanted and no more.
+  expect_equal(file.info(path)$size, 8)
+
+  result <- expect_silent(get_string(path))
+  expect_equal(result, "12345678")
+})


### PR DESCRIPTION
By default `readLines` throws a warning when reading from a file with no trailing newline. We can silence that by passing `warn = FALSE`.